### PR TITLE
feat: add OpenCode plugin support (closes #6)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ export function createProgram(): Command {
   program
     .command("init")
     .description("Initialize .wolf/ in current project")
+    .option("--opencode", "Register OpenCode plugin instead of Claude Code hooks")
     .action(initCommand);
 
   program

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -118,7 +118,11 @@ const HOOK_SETTINGS = {
   },
 };
 
-export async function initCommand(): Promise<void> {
+export interface InitOptions {
+  opencode?: boolean;
+}
+
+export async function initCommand(opts: InitOptions = {}): Promise<void> {
   // Check Node.js version
   const nodeVersion = parseInt(process.version.slice(1), 10);
   if (nodeVersion < 20) {
@@ -182,35 +186,40 @@ export async function initCommand(): Promise<void> {
   // --- Hook scripts: always update (bug fixes, new features) ---
   copyHookScripts(wolfDir);
 
-  // --- Claude settings: replace OpenWolf hooks (upgrade old paths) ---
-  const claudeDir = path.join(projectRoot, ".claude");
-  ensureDir(claudeDir);
-
-  const settingsPath = path.join(claudeDir, "settings.json");
-  if (fs.existsSync(settingsPath)) {
-    const existing = readJSON<Record<string, unknown>>(settingsPath, {});
-    const merged = replaceOpenWolfHooks(existing, HOOK_SETTINGS);
-    writeJSON(settingsPath, merged);
+  if (opts.opencode) {
+    // --- OpenCode plugin ---
+    initOpenCode(projectRoot, actualTemplatesDir);
   } else {
-    writeJSON(settingsPath, HOOK_SETTINGS);
-  }
+    // --- Claude settings: replace OpenWolf hooks (upgrade old paths) ---
+    const claudeDir = path.join(projectRoot, ".claude");
+    ensureDir(claudeDir);
 
-  // --- Claude rules: always update ---
-  const rulesDir = path.join(claudeDir, "rules");
-  ensureDir(rulesDir);
-  const rulesContent = readTemplateContent("claude-rules-openwolf.md", actualTemplatesDir);
-  writeText(path.join(rulesDir, "openwolf.md"), rulesContent);
-
-  // --- CLAUDE.md: add snippet if missing ---
-  const claudeMdPath = path.join(projectRoot, "CLAUDE.md");
-  const snippetContent = readTemplateContent("claude-md-snippet.md", actualTemplatesDir);
-  if (fs.existsSync(claudeMdPath)) {
-    const existing = readText(claudeMdPath);
-    if (!existing.includes("OpenWolf")) {
-      writeText(claudeMdPath, snippetContent + "\n\n" + existing);
+    const settingsPath = path.join(claudeDir, "settings.json");
+    if (fs.existsSync(settingsPath)) {
+      const existing = readJSON<Record<string, unknown>>(settingsPath, {});
+      const merged = replaceOpenWolfHooks(existing, HOOK_SETTINGS);
+      writeJSON(settingsPath, merged);
+    } else {
+      writeJSON(settingsPath, HOOK_SETTINGS);
     }
-  } else {
-    writeText(claudeMdPath, snippetContent);
+
+    // --- Claude rules: always update ---
+    const rulesDir = path.join(claudeDir, "rules");
+    ensureDir(rulesDir);
+    const rulesContent = readTemplateContent("claude-rules-openwolf.md", actualTemplatesDir);
+    writeText(path.join(rulesDir, "openwolf.md"), rulesContent);
+
+    // --- CLAUDE.md: add snippet if missing ---
+    const claudeMdPath = path.join(projectRoot, "CLAUDE.md");
+    const snippetContent = readTemplateContent("claude-md-snippet.md", actualTemplatesDir);
+    if (fs.existsSync(claudeMdPath)) {
+      const existing = readText(claudeMdPath);
+      if (!existing.includes("OpenWolf")) {
+        writeText(claudeMdPath, snippetContent + "\n\n" + existing);
+      }
+    } else {
+      writeText(claudeMdPath, snippetContent);
+    }
   }
 
   // --- Anatomy scan: only on fresh init ---
@@ -277,14 +286,23 @@ export async function initCommand(): Promise<void> {
   } else {
     console.log(`  ✓ OpenWolf v${version} initialized`);
     console.log(`  ✓ .wolf/ created with ${createdCount} files`);
-    console.log(`  ✓ Claude Code hooks registered (6 hooks)`);
-    console.log(`  ✓ CLAUDE.md updated`);
-    console.log(`  ✓ .claude/rules/openwolf.md created`);
+    if (opts.opencode) {
+      console.log(`  ✓ OpenCode plugin registered (.opencode/plugin/openwolf.ts)`);
+      console.log(`  ✓ opencode.md updated`);
+    } else {
+      console.log(`  ✓ Claude Code hooks registered (6 hooks)`);
+      console.log(`  ✓ CLAUDE.md updated`);
+      console.log(`  ✓ .claude/rules/openwolf.md created`);
+    }
     console.log(`  ✓ Anatomy scan: ${fileCount} files indexed`);
   }
   console.log(`  ✓ Daemon: ${daemonStatus}`);
   console.log("");
-  console.log("  You're ready. Just use 'claude' as normal — OpenWolf is watching.");
+  if (opts.opencode) {
+    console.log("  You're ready. Just use 'opencode' as normal — OpenWolf is watching.");
+  } else {
+    console.log("  You're ready. Just use 'claude' as normal — OpenWolf is watching.");
+  }
   console.log("");
 }
 
@@ -324,6 +342,7 @@ function readTemplateContent(filename: string, templatesDir: string): string {
 function getEmbeddedTemplate(filename: string): string {
   const templates: Record<string, string> = {
     "claude-md-snippet.md": `# OpenWolf\n\n@.wolf/OPENWOLF.md\n\nThis project uses OpenWolf for context management. Read and follow .wolf/OPENWOLF.md every session. Check .wolf/cerebrum.md before generating code. Check .wolf/anatomy.md before reading files.`,
+    "opencode-md-snippet.md": `# OpenWolf\n\n@.wolf/OPENWOLF.md\n\nThis project uses OpenWolf for context management. Read and follow .wolf/OPENWOLF.md every session. Check .wolf/cerebrum.md before generating code. Check .wolf/anatomy.md before reading files.`,
     "claude-rules-openwolf.md": `---\ndescription: OpenWolf protocol enforcement — active on all files\nglobs: **/*\n---\n\n- Check .wolf/anatomy.md before reading any project file\n- Check .wolf/cerebrum.md Do-Not-Repeat list before generating code\n- After writing or editing files, update .wolf/anatomy.md and append to .wolf/memory.md\n- After receiving a user correction, update .wolf/cerebrum.md immediately (Preferences, Learnings, or Do-Not-Repeat)\n- LEARN from every interaction: if you discover a convention, user preference, or project pattern, add it to .wolf/cerebrum.md. Low threshold — when in doubt, log it.\n- BEFORE fixing any bug or error: read .wolf/buglog.json for known fixes\n- AFTER fixing any bug, error, failed test, failed build, or user-reported problem: ALWAYS log to .wolf/buglog.json with error_message, root_cause, fix, and tags\n- If you edit a file more than twice in a session, that likely indicates a bug — log it to .wolf/buglog.json\n- When the user asks to check/evaluate UI design: run \`openwolf designqc\` to capture screenshots, then read them from .wolf/designqc-captures/\n- When the user asks to change/pick/migrate UI framework: read .wolf/reframe-frameworks.md, ask decision questions, recommend a framework, then execute with the framework's prompt`,
   };
   return templates[filename] ?? "";
@@ -465,6 +484,74 @@ function copyHookScripts(wolfDir: string): void {
   // Always write a package.json with type:module so ESM hooks work in any project
   const hooksPkgPath = path.join(hooksDir, "package.json");
   fs.writeFileSync(hooksPkgPath, JSON.stringify({ type: "module" }, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Initialize OpenCode plugin for OpenWolf.
+ * Creates .opencode/plugin/openwolf.ts and injects snippet into opencode.md.
+ */
+function initOpenCode(projectRoot: string, templatesDir: string): void {
+  // Create .opencode/plugin/ directory
+  const pluginDir = path.join(projectRoot, ".opencode", "plugin");
+  ensureDir(pluginDir);
+
+  // Copy the plugin template directory
+  const pluginSrcDir = path.join(templatesDir, "opencode-plugin");
+  const pluginDestDir = path.join(pluginDir, "openwolf");
+
+  if (fs.existsSync(pluginSrcDir)) {
+    copyPluginDirectory(pluginSrcDir, pluginDestDir);
+  } else {
+    // Fallback: write embedded version
+    const pluginDest = path.join(pluginDir, "openwolf.ts");
+    fs.writeFileSync(pluginDest, getEmbeddedOpenCodePlugin(), "utf-8");
+  }
+
+  // Inject snippet into opencode.md (OpenCode's equivalent of CLAUDE.md)
+  const opencodeMdPath = path.join(projectRoot, "opencode.md");
+  const snippetContent = readTemplateContent("opencode-md-snippet.md", templatesDir);
+  if (fs.existsSync(opencodeMdPath)) {
+    const existing = readText(opencodeMdPath);
+    if (!existing.includes("OpenWolf")) {
+      writeText(opencodeMdPath, snippetContent + "\n\n" + existing);
+    }
+  } else {
+    writeText(opencodeMdPath, snippetContent);
+  }
+}
+
+function copyPluginDirectory(srcDir: string, destDir: string): void {
+  ensureDir(destDir);
+  const files = fs.readdirSync(srcDir);
+  for (const file of files) {
+    const srcPath = path.join(srcDir, file);
+    const destPath = path.join(destDir, file);
+    if (fs.statSync(srcPath).isDirectory()) {
+      copyPluginDirectory(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function getEmbeddedOpenCodePlugin(): string {
+  return `import type { Plugin } from "@opencode-ai/plugin"
+// OpenWolf plugin — auto-generated by openwolf init
+// For the full implementation, see the openwolf source repository.
+export const OpenWolf: Plugin = async ({ directory }) => {
+  return {
+    event: async ({ event }) => {
+      // Session lifecycle handled by .wolf/ infrastructure
+    },
+    "tool.execute.before": async (_input, _output) => {},
+    "tool.execute.after": async (_input, _output) => {},
+    stop: async (_input) => {},
+    "experimental.chat.system.transform": async (_input, output) => {
+      output.system.push("This project uses OpenWolf. Read .wolf/OPENWOLF.md for protocol instructions.")
+    },
+  }
+}
+`;
 }
 
 /**

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -2,10 +2,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
 
-export function getWolfDir(): string {
+export function getWolfDir(projectDir?: string): string {
   // Prefer CLAUDE_PROJECT_DIR so hooks work even if CWD changes during a session
-  const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
-  return path.join(projectDir, ".wolf");
+  const dir = projectDir || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  return path.join(dir, ".wolf");
 }
 
 /**
@@ -17,6 +17,14 @@ export function ensureWolfDir(): void {
   if (!fs.existsSync(wolfDir)) {
     process.exit(0);
   }
+}
+
+/**
+ * Check if .wolf/ directory exists without exiting.
+ * Used by the OpenCode plugin to skip processing in non-OpenWolf projects.
+ */
+export function wolfDirExists(): boolean {
+  return fs.existsSync(getWolfDir());
 }
 
 export function readJSON<T = unknown>(filePath: string, fallback: T): T {

--- a/src/templates/opencode-md-snippet.md
+++ b/src/templates/opencode-md-snippet.md
@@ -1,0 +1,5 @@
+# OpenWolf
+
+@.wolf/OPENWOLF.md
+
+This project uses OpenWolf for context management. Read and follow .wolf/OPENWOLF.md every session. Check .wolf/cerebrum.md before generating code. Check .wolf/anatomy.md before reading files.

--- a/src/templates/opencode-plugin/anatomy.ts
+++ b/src/templates/opencode-plugin/anatomy.ts
@@ -1,0 +1,96 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import type { AnatomyEntry } from "./types.js"
+
+export function parseAnatomy(content: string): Map<string, AnatomyEntry[]> {
+  const sections = new Map<string, AnatomyEntry[]>()
+  let currentSection = ""
+  for (const line of content.split("\n")) {
+    const sm = line.match(/^## (.+)/)
+    if (sm) {
+      currentSection = sm[1].trim()
+      if (!sections.has(currentSection)) sections.set(currentSection, [])
+      continue
+    }
+    if (!currentSection) continue
+    const em = line.match(/^- `([^`]+)`(?:\s+—\s+(.+?))?\s*\(~(\d+)\s+tok\)$/)
+    if (em) {
+      sections.get(currentSection)!.push({
+        file: em[1],
+        description: em[2] || "",
+        tokens: parseInt(em[3], 10),
+      })
+    }
+  }
+  return sections
+}
+
+export function serializeAnatomy(
+  sections: Map<string, AnatomyEntry[]>,
+  metadata: { lastScanned: string; fileCount: number; hits: number; misses: number }
+): string {
+  const lines: string[] = [
+    "# anatomy.md",
+    "",
+    `> Auto-maintained by OpenWolf. Last scanned: ${metadata.lastScanned}`,
+    `> Files: ${metadata.fileCount} tracked | Anatomy hits: ${metadata.hits} | Misses: ${metadata.misses}`,
+    "",
+  ]
+  const keys = [...sections.keys()].sort()
+  for (const key of keys) {
+    lines.push(`## ${key}`)
+    lines.push("")
+    const entries = sections.get(key)!.sort((a, b) => a.file.localeCompare(b.file))
+    for (const e of entries) {
+      const desc = e.description ? ` — ${e.description}` : ""
+      lines.push(`- \`${e.file}\`${desc} (~${e.tokens} tok)`)
+    }
+    lines.push("")
+  }
+  return lines.join("\n")
+}
+
+export function extractDescription(filePath: string): string {
+  const MAX_DESC = 150
+  const basename = path.basename(filePath)
+  const ext = path.extname(basename).toLowerCase()
+  const known: Record<string, string> = {
+    "package.json": "Node.js package manifest",
+    "tsconfig.json": "TypeScript configuration",
+    ".gitignore": "Git ignore rules",
+    "README.md": "Project documentation",
+  }
+  if (known[basename]) return known[basename]
+
+  let content: string
+  try {
+    const fd = fs.openSync(filePath, "r")
+    const buf = Buffer.alloc(12288)
+    const n = fs.readSync(fd, buf, 0, 12288, 0)
+    fs.closeSync(fd)
+    content = buf.subarray(0, n).toString("utf-8")
+  } catch {
+    return ""
+  }
+  if (!content.trim()) return ""
+
+  const cap = (s: string) => s.length <= MAX_DESC ? s : s.slice(0, MAX_DESC - 3) + "..."
+
+  if (ext === ".md" || ext === ".mdx") {
+    const m = content.match(/^#{1,2}\s+(.+)$/m)
+    if (m) return cap(m[1].trim())
+  }
+
+  if (ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx") {
+    if (basename === "page.tsx" || basename === "page.js") return "Next.js page component"
+    if (basename === "layout.tsx" || basename === "layout.js") return "Next.js layout"
+    const exports = (content.match(/export\s+(?:async\s+)?(?:function|class|const|interface|type|enum)\s+(\w+)/g) || [])
+      .map(e => e.match(/(\w+)$/)?.[1]).filter(Boolean) as string[]
+    if (exports.length > 0 && exports.length <= 5) return `Exports ${exports.join(", ")}`
+    if (exports.length > 5) return cap(`Exports ${exports.slice(0, 4).join(", ")} + ${exports.length - 4} more`)
+  }
+
+  const declM = content.match(/(?:function|class|const|interface|type|enum)\s+(\w+)/)
+  if (declM) return `Declares ${declM[1]}`
+  return ""
+}

--- a/src/templates/opencode-plugin/fs.ts
+++ b/src/templates/opencode-plugin/fs.ts
@@ -1,0 +1,64 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import * as crypto from "node:crypto"
+
+export function getWolfDir(directory: string): string {
+  return path.join(directory, ".wolf")
+}
+
+export function wolfDirExists(directory: string): boolean {
+  return fs.existsSync(getWolfDir(directory))
+}
+
+export function readJSON<T>(filePath: string, fallback: T): T {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as T
+  } catch {
+    return fallback
+  }
+}
+
+export function writeJSON(filePath: string, data: unknown): void {
+  const dir = path.dirname(filePath)
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  const tmp = filePath + "." + crypto.randomBytes(4).toString("hex") + ".tmp"
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(data, null, 2), "utf-8")
+    fs.renameSync(tmp, filePath)
+  } catch {
+    try { fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8") } catch {}
+    try { fs.unlinkSync(tmp) } catch {}
+  }
+}
+
+export function readMarkdown(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, "utf-8")
+  } catch {
+    return ""
+  }
+}
+
+export function appendMarkdown(filePath: string, line: string): void {
+  const dir = path.dirname(filePath)
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  fs.appendFileSync(filePath, line, "utf-8")
+}
+
+export function timeShort(): string {
+  const d = new Date()
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`
+}
+
+export function timestamp(): string {
+  return new Date().toISOString()
+}
+
+export function normalizePath(p: string): string {
+  return p.replace(/\\/g, "/")
+}
+
+export function estimateTokens(text: string, type: "code" | "prose" | "mixed" = "mixed"): number {
+  const ratio = type === "code" ? 3.5 : type === "prose" ? 4.0 : 3.75
+  return Math.ceil(text.length / ratio)
+}

--- a/src/templates/opencode-plugin/index.ts
+++ b/src/templates/opencode-plugin/index.ts
@@ -1,0 +1,99 @@
+import type { Plugin } from "@opencode-ai/plugin"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+import { wolfDirExists, getWolfDir } from "./fs.js"
+import { handleSessionStart, deleteSession } from "./session.js"
+import { handlePreRead } from "./pre-read.js"
+import { handlePreWrite } from "./pre-write.js"
+import { handlePostRead } from "./post-read.js"
+import { handlePostWrite } from "./post-write.js"
+import { handleStop } from "./stop.js"
+
+export const OpenWolf: Plugin = async ({ directory }: { directory: string }) => {
+  return {
+    event: async ({ event }: { event: { type: string; [key: string]: unknown } }) => {
+      if (event.type === "session.created" && !wolfDirExists(directory)) return
+
+      const sessionId = (event as any).session_id || (event as any).sessionID
+      if (!sessionId) return
+
+      if (event.type === "session.created") {
+        handleSessionStart(directory, sessionId)
+      }
+
+      if (event.type === "session.deleted") {
+        deleteSession(sessionId)
+      }
+    },
+
+    "tool.execute.before": async (input: { tool: string; sessionID: string }, output: { args: Record<string, unknown> }) => {
+      if (!wolfDirExists(directory)) return
+
+      const sessionId = input.sessionID
+      if (!sessionId) return
+
+      const args: Record<string, unknown> = output.args || {}
+      const tool = input.tool.toLowerCase()
+
+      if (tool === "read") {
+        const filePath = String(args.filePath || args.file_path || "")
+        if (filePath) handlePreRead(directory, sessionId, filePath)
+      }
+
+      if (tool === "write" || tool === "edit") {
+        const filePath = String(args.filePath || args.file_path || "")
+        const content = String(args.content || "")
+        const oldStr = String(args.old_string || args.oldString || "")
+        const newStr = String(args.new_string || args.newString || "")
+        if (filePath) handlePreWrite(directory, sessionId, filePath, content, oldStr, newStr)
+      }
+    },
+
+    "tool.execute.after": async (input: { tool: string; sessionID: string; args: Record<string, unknown> }, output: Record<string, unknown>) => {
+      if (!wolfDirExists(directory)) return
+
+      const sessionId = input.sessionID
+      if (!sessionId) return
+
+      const tool = input.tool.toLowerCase()
+      const args = input.args || {}
+
+      if (tool === "read") {
+        const filePath = String(args.filePath || args.file_path || "")
+        const content = String((output as any).output || "")
+        if (filePath) handlePostRead(directory, sessionId, filePath, content)
+      }
+
+      if (tool === "write" || tool === "edit") {
+        const filePath = args.filePath || args.file_path || ""
+        const content = String(args.content || "")
+        const oldStr = String(args.old_string || args.oldString || "")
+        const newStr = String(args.new_string || args.newString || "")
+        if (filePath) handlePostWrite(directory, sessionId, input.tool, filePath, content, oldStr, newStr)
+      }
+    },
+
+    stop: async (input: Record<string, unknown>) => {
+      if (!wolfDirExists(directory)) return
+
+      const sessionId = (input as any).sessionID || (input as any).session_id
+      if (!sessionId) return
+
+      handleStop(directory, sessionId)
+    },
+
+    "experimental.chat.system.transform": async (_input: Record<string, unknown>, output: { system: string[] }) => {
+      if (!wolfDirExists(directory)) return
+
+      const wolfDir = getWolfDir(directory)
+      const openwolfPath = path.join(wolfDir, "OPENWOLF.md")
+      if (fs.existsSync(openwolfPath)) {
+        try {
+          const openwolfContent = fs.readFileSync(openwolfPath, "utf-8")
+          output.system.push(`\n<openwolf-protocol>\n${openwolfContent}\n</openwolf-protocol>`)
+        } catch {}
+      }
+    },
+  }
+}

--- a/src/templates/opencode-plugin/post-read.ts
+++ b/src/templates/opencode-plugin/post-read.ts
@@ -1,0 +1,57 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { getWolfDir, writeJSON, readJSON, normalizePath, readMarkdown, estimateTokens } from "./fs.js"
+import { parseAnatomy } from "./anatomy.js"
+import type { PartialSessionState } from "./types.js"
+
+export function handlePostRead(directory: string, sessionId: string, filePath: string, content: string): void {
+  const wolfDir = getWolfDir(directory)
+  if (!fs.existsSync(wolfDir)) return
+
+  const hooksDir = path.join(wolfDir, "hooks")
+  const sessionFile = path.join(hooksDir, "_session.json")
+  const normalizedFile = normalizePath(filePath)
+
+  const projectDir = normalizePath(directory)
+  const relToProject = normalizedFile.startsWith(projectDir)
+    ? normalizedFile.slice(projectDir.length).replace(/^\//, "")
+    : ""
+  if (relToProject.startsWith(".wolf/") || relToProject.startsWith(".wolf\\")) return
+
+  const ext = path.extname(filePath).toLowerCase()
+  const codeExts = new Set([".ts", ".js", ".tsx", ".jsx", ".py", ".rs", ".go", ".java", ".c", ".cpp", ".css", ".json", ".yaml", ".yml"])
+  const proseExts = new Set([".md", ".txt", ".rst"])
+  const type = codeExts.has(ext) ? "code" : proseExts.has(ext) ? "prose" : "mixed"
+
+  let tokens = content ? estimateTokens(content, type as "code" | "prose" | "mixed") : 0
+
+  if (tokens === 0) {
+    const anatomyContent = readMarkdown(path.join(wolfDir, "anatomy.md"))
+    const sections = parseAnatomy(anatomyContent)
+    for (const [, entries] of sections) {
+      for (const entry of entries) {
+        const entryRelPath = normalizePath(path.join(entry.file))
+        if (normalizedFile.endsWith(entryRelPath) || normalizedFile.endsWith("/" + entryRelPath)) {
+          tokens = entry.tokens
+          break
+        }
+      }
+      if (tokens > 0) break
+    }
+  }
+
+  const session = readJSON<PartialSessionState>(sessionFile, { files_read: {} })
+  if (!session.files_read) session.files_read = {}
+  
+  if (session.files_read[normalizedFile]) {
+    session.files_read[normalizedFile].tokens = tokens
+  } else {
+    session.files_read[normalizedFile] = {
+      count: 1,
+      tokens,
+      first_read: new Date().toISOString(),
+    }
+  }
+
+  writeJSON(sessionFile, session)
+}

--- a/src/templates/opencode-plugin/post-write.ts
+++ b/src/templates/opencode-plugin/post-write.ts
@@ -1,0 +1,283 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import * as crypto from "node:crypto"
+import { getWolfDir, writeJSON, readJSON, appendMarkdown, timeShort, normalizePath, estimateTokens } from "./fs.js"
+import { parseAnatomy, serializeAnatomy, extractDescription } from "./anatomy.js"
+import type { PartialSessionState, FixDetection } from "./types.js"
+
+export function handlePostWrite(
+  directory: string,
+  sessionId: string,
+  toolName: string,
+  filePath: string,
+  content: string,
+  oldStr: string,
+  newStr: string
+): void {
+  const wolfDir = getWolfDir(directory)
+  if (!fs.existsSync(wolfDir)) return
+
+  const hooksDir = path.join(wolfDir, "hooks")
+  const sessionFile = path.join(hooksDir, "_session.json")
+  const projectRoot = directory
+
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(projectRoot, filePath)
+  const relPath = normalizePath(path.relative(projectRoot, absolutePath))
+  if (relPath.startsWith(".wolf/")) return
+
+  const baseName = path.basename(absolutePath)
+  if (baseName === ".env" || baseName.startsWith(".env.")) return
+
+  updateAnatomy(wolfDir, absolutePath, projectRoot, content)
+  appendToMemory(wolfDir, toolName, absolutePath, projectRoot, content, newStr)
+  trackSession(wolfDir, sessionFile, filePath, toolName, content, newStr, baseName)
+  
+  if (oldStr && newStr) {
+    autoDetectBugFix(wolfDir, absolutePath, projectRoot, oldStr, newStr)
+  }
+}
+
+function updateAnatomy(wolfDir: string, absolutePath: string, projectRoot: string, content: string): void {
+  try {
+    const anatomyPath = path.join(wolfDir, "anatomy.md")
+    let anatomyContent: string
+    try {
+      anatomyContent = fs.readFileSync(anatomyPath, "utf-8")
+    } catch {
+      anatomyContent = "# anatomy.md\n\n> Auto-maintained by OpenWolf.\n"
+    }
+
+    const sections = parseAnatomy(anatomyContent)
+    const relPathLocal = normalizePath(path.relative(projectRoot, absolutePath))
+    const dir = path.dirname(relPathLocal)
+    const fileName = path.basename(relPathLocal)
+    const sectionKey = dir === "." ? "./" : dir + "/"
+
+    let fileContent = ""
+    try {
+      fileContent = fs.readFileSync(absolutePath, "utf-8")
+    } catch {
+      fileContent = content ?? ""
+    }
+
+    const desc = extractDescription(absolutePath).slice(0, 100)
+    const ext = path.extname(absolutePath).toLowerCase()
+    const codeExts = new Set([".ts", ".js", ".tsx", ".jsx", ".py", ".json", ".yaml", ".yml", ".css"])
+    const proseExts = new Set([".md", ".txt", ".rst"])
+    const type = codeExts.has(ext) ? "code" : proseExts.has(ext) ? "prose" : "mixed"
+    const tokens = estimateTokens(fileContent, type as "code" | "prose" | "mixed")
+
+    if (!sections.has(sectionKey)) sections.set(sectionKey, [])
+    const entries = sections.get(sectionKey)!
+    const idx = entries.findIndex((e) => e.file === fileName)
+    if (idx !== -1) {
+      entries[idx] = { file: fileName, description: desc, tokens }
+    } else {
+      entries.push({ file: fileName, description: desc, tokens })
+    }
+
+    let fileCount = 0
+    for (const [, list] of sections) fileCount += list.length
+
+    const serialized = serializeAnatomy(sections, {
+      lastScanned: new Date().toISOString(),
+      fileCount,
+      hits: 0,
+      misses: 0,
+    })
+
+    const tmp = anatomyPath + "." + crypto.randomBytes(4).toString("hex") + ".tmp"
+    try {
+      fs.writeFileSync(tmp, serialized, "utf-8")
+      fs.renameSync(tmp, anatomyPath)
+    } catch {
+      try { fs.writeFileSync(anatomyPath, serialized, "utf-8") } catch {}
+      try { fs.unlinkSync(tmp) } catch {}
+    }
+  } catch {}
+}
+
+function appendToMemory(
+  wolfDir: string,
+  toolName: string,
+  absolutePath: string,
+  projectRoot: string,
+  content: string,
+  newStr: string
+): void {
+  try {
+    const action = toolName === "Write" ? "Created" : toolName === "MultiEdit" ? "Multi-edited" : "Edited"
+    const relFile = normalizePath(path.relative(projectRoot, absolutePath))
+    const fileContent = content ?? ""
+    const ext = path.extname(absolutePath).toLowerCase()
+    const codeExts = new Set([".ts", ".js", ".tsx", ".jsx", ".py", ".json", ".yaml", ".yml", ".css"])
+    const type = codeExts.has(ext) ? "code" : "mixed"
+    const writeTokens = estimateTokens(fileContent || newStr, type as "code" | "prose" | "mixed")
+
+    let changeDesc = ""
+    if (content && newStr) {
+      changeDesc = summarizeEdit(content, newStr, path.basename(absolutePath))
+    }
+
+    const memoryPath = path.join(wolfDir, "memory.md")
+    const outcome = changeDesc || "—"
+    appendMarkdown(memoryPath, `| ${timeShort()} | ${action} ${relFile} | ${outcome} | ~${writeTokens} |\n`)
+  } catch {}
+}
+
+function trackSession(
+  wolfDir: string,
+  sessionFile: string,
+  filePath: string,
+  toolName: string,
+  content: string,
+  newStr: string,
+  baseName: string
+): void {
+  try {
+    const session = readJSON<PartialSessionState>(sessionFile, { files_written: [], edit_counts: {} })
+    if (!session.edit_counts) session.edit_counts = {}
+
+    const normalizedFile = normalizePath(filePath)
+    const action = toolName === "Write" ? "create" : "edit"
+    const fileContent = content ?? ""
+    const tokens = estimateTokens(fileContent || newStr, "code")
+
+    session.files_written!.push({
+      file: normalizedFile,
+      action,
+      tokens,
+      at: new Date().toISOString(),
+    })
+
+    const editKey = normalizePath(path.relative(wolfDir.replace("/.wolf", ""), path.join(wolfDir.replace("/.wolf", ""), filePath)))
+    session.edit_counts![editKey] = (session.edit_counts![editKey] || 0) + 1
+
+    writeJSON(sessionFile, session)
+
+    if (session.edit_counts![editKey] >= 3) {
+      console.warn(`⚠️ OpenWolf: ${baseName} has been edited ${session.edit_counts![editKey]} times this session. If you're fixing a bug, remember to log it to .wolf/buglog.json.`)
+    }
+  } catch {}
+}
+
+export function summarizeEdit(oldStr: string, newStr: string, filename: string): string {
+  const oldLines = oldStr.split("\n")
+  const newLines = newStr.split("\n")
+  const oldCount = oldLines.length
+  const newCount = newLines.length
+
+  if (newStr.includes("try") && newStr.includes("catch") && !oldStr.includes("catch")) return "added error handling"
+  if (newStr.includes("?.") && !oldStr.includes("?.")) return "added optional chaining"
+  if (newStr.includes("?? ") && !oldStr.includes("?? ")) return "added nullish coalescing"
+
+  if (!newStr.trim() || newStr.trim().length < oldStr.trim().length * 0.2) return `removed ${oldCount} lines`
+
+  const oldImports = oldLines.filter(l => /^\s*(import|require|use |from )/.test(l)).length
+  const newImports = newLines.filter(l => /^\s*(import|require|use |from )/.test(l)).length
+  if (newImports > oldImports && Math.abs(newCount - oldCount) <= newImports - oldImports + 1) return `added ${newImports - oldImports} import(s)`
+
+  if (oldCount === 1 && newCount === 1) {
+    const o = oldStr.trim()
+    const n = newStr.trim()
+    const oStr = o.match(/['"`]([^'"`]+)['"`]/)
+    const nStr = n.match(/['"`]([^'"`]+)['"`]/)
+    if (oStr && nStr && oStr[1] !== nStr[1]) return `"${oStr[1].slice(0, 25)}" → "${nStr[1].slice(0, 25)}"`
+    return "inline fix"
+  }
+
+  const fnMatch = newStr.match(/(?:function|def|fn|func|async\s+function)\s+(\w+)/)
+  if (fnMatch) return `modified ${fnMatch[1]}()`
+
+  if (newCount > oldCount + 5) return `expanded (+${newCount - oldCount} lines)`
+  if (oldCount > newCount + 5) return `reduced (-${oldCount - newCount} lines)`
+
+  return `${oldCount}→${newCount} lines`
+}
+
+export function autoDetectBugFix(wolfDir: string, absolutePath: string, projectRoot: string, oldStr: string, newStr: string): void {
+  const bugLogPath = path.join(wolfDir, "buglog.json")
+  const bugLog = readJSON<{ version: number; bugs: Array<{ id: string; timestamp: string; error_message: string; file: string; root_cause: string; fix: string; tags: string[]; related_bugs: string[]; occurrences: number; last_seen: string }> }>(bugLogPath, { version: 1, bugs: [] })
+  const relFile = normalizePath(path.relative(projectRoot, absolutePath))
+  const basename = path.basename(absolutePath)
+  const ext = path.extname(basename).toLowerCase()
+
+  const detection = detectFixPattern(oldStr, newStr, ext, basename)
+  if (!detection) return
+
+  const recentDupe = bugLog.bugs.find(b => {
+    if (path.basename(b.file) !== basename) return false
+    if (!b.tags.includes("auto-detected")) return false
+    if (!b.tags.includes(detection.category)) return false
+    const bugTime = new Date(b.last_seen).getTime()
+    return (Date.now() - bugTime) < 5 * 60 * 1000
+  })
+
+  if (recentDupe) {
+    recentDupe.occurrences++
+    recentDupe.last_seen = new Date().toISOString()
+    if (detection.context && !recentDupe.fix.includes(detection.context)) {
+      recentDupe.fix += ` | Also: ${detection.context}`
+    }
+    writeJSON(bugLogPath, bugLog)
+    return
+  }
+
+  const nextId = `bug-${String(bugLog.bugs.length + 1).padStart(3, "0")}`
+  bugLog.bugs.push({
+    id: nextId,
+    timestamp: new Date().toISOString(),
+    error_message: detection.summary,
+    file: relFile,
+    root_cause: detection.rootCause,
+    fix: detection.fix,
+    tags: ["auto-detected", detection.category, ext.replace(".", "") || "unknown"],
+    related_bugs: [],
+    occurrences: 1,
+    last_seen: new Date().toISOString(),
+  })
+  writeJSON(bugLogPath, bugLog)
+}
+
+export function detectFixPattern(oldStr: string, newStr: string, ext: string, basename: string): FixDetection | null {
+  const oldLines = oldStr.split("\n")
+  const newLines = newStr.split("\n")
+
+  if (newStr.includes("catch") && !oldStr.includes("catch")) {
+    const fn = newStr.match(/(?:function|def|async)\s+(\w+)/)?.[1] || "unknown"
+    return { category: "error-handling", summary: `Missing error handling in ${fn}`, rootCause: "Code path had no error handling", fix: "Added try/catch block", context: extractChangedLines(oldStr, newStr) }
+  }
+
+  if ((newStr.includes("?.") && !oldStr.includes("?.")) || (newStr.includes("?? ") && !oldStr.includes("?? "))) {
+    return { category: "null-safety", summary: `Null/undefined access in ${basename}`, rootCause: "Property access on potentially null/undefined value", fix: "Added null safety", context: extractChangedLines(oldStr, newStr) }
+  }
+
+  if (/if\s*\([^)]*\)\s*(return|throw|continue|break)/.test(newStr) && !/if\s*\([^)]*\)\s*(return|throw|continue|break)/.test(oldStr)) {
+    const condition = newStr.match(/if\s*\(([^)]+)\)/)?.[1]?.trim().slice(0, 60) || "condition"
+    return { category: "guard-clause", summary: "Missing guard clause", rootCause: `No early return for: ${condition}`, fix: `Added guard clause: if (${condition.slice(0, 40)})` }
+  }
+
+  if (oldLines.length <= 3 && newLines.length <= 3) {
+    const oStrs = oldStr.trim().match(/['"`]([^'"`]{2,})['"`]/g) || []
+    const nStrs = newStr.trim().match(/['"`]([^'"`]{2,})['"`]/g) || []
+    if (oStrs.length > 0 && nStrs.length > 0) {
+      for (let i = 0; i < Math.min(oStrs.length, nStrs.length); i++) {
+        if (oStrs[i] !== nStrs[i]) {
+          return { category: "wrong-value", summary: "Incorrect value in code", rootCause: `Had ${oStrs[i].slice(0, 50)}`, fix: `Changed to ${nStrs[i].slice(0, 50)}` }
+        }
+      }
+    }
+  }
+
+  if (newStr.includes("await ") && !oldStr.includes("await ")) {
+    return { category: "async-fix", summary: "Missing await", rootCause: "Async call without await", fix: "Added await to async call", context: extractChangedLines(oldStr, newStr) }
+  }
+
+  return null
+}
+
+function extractChangedLines(oldStr: string, newStr: string): string {
+  const oldLines = new Set(oldStr.split("\n").map(l => l.trim()).filter(Boolean))
+  const added = newStr.split("\n").map(l => l.trim()).filter(l => l && !oldLines.has(l))
+  return added.slice(0, 2).map(l => l.slice(0, 60)).join("; ")
+}

--- a/src/templates/opencode-plugin/pre-read.ts
+++ b/src/templates/opencode-plugin/pre-read.ts
@@ -1,0 +1,63 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { getWolfDir, writeJSON, readJSON, normalizePath, readMarkdown } from "./fs.js"
+import { parseAnatomy } from "./anatomy.js"
+import type { PartialSessionState } from "./types.js"
+
+export function handlePreRead(directory: string, sessionId: string, filePath: string): void {
+  const wolfDir = getWolfDir(directory)
+  if (!fs.existsSync(wolfDir)) return
+
+  const hooksDir = path.join(wolfDir, "hooks")
+  const sessionFile = path.join(hooksDir, "_session.json")
+  const normalizedFile = normalizePath(filePath)
+
+  const projectDir = normalizePath(directory)
+  const relToProject = normalizedFile.startsWith(projectDir)
+    ? normalizedFile.slice(projectDir.length).replace(/^\//, "")
+    : ""
+  if (relToProject.startsWith(".wolf/") || relToProject.startsWith(".wolf\\")) return
+
+  const session = readJSON<PartialSessionState>(sessionFile, {
+    session_id: "", files_read: {}, anatomy_hits: 0, anatomy_misses: 0,
+    repeated_reads_warned: 0,
+  })
+
+  if (!session.files_read) session.files_read = {}
+
+  if (session.files_read[normalizedFile]) {
+    const prev = session.files_read[normalizedFile]
+    console.warn(`⚡ OpenWolf: ${path.basename(normalizedFile)} was already read this session (~${prev.tokens} tokens). Consider using your existing knowledge of this file.`)
+    session.files_read[normalizedFile].count++
+    session.repeated_reads_warned = (session.repeated_reads_warned || 0) + 1
+    writeJSON(sessionFile, session)
+    return
+  }
+
+  const anatomyContent = readMarkdown(path.join(wolfDir, "anatomy.md"))
+  const sections = parseAnatomy(anatomyContent)
+  let found = false
+
+  for (const [sectionKey, entries] of sections) {
+    for (const entry of entries) {
+      const entryRelPath = normalizePath(path.join(sectionKey, entry.file))
+      if (normalizedFile.endsWith(entryRelPath) || normalizedFile.endsWith("/" + entryRelPath)) {
+        console.warn(`📋 OpenWolf anatomy: ${entry.file} — ${entry.description} (~${entry.tokens} tok)`)
+        found = true
+        break
+      }
+    }
+    if (found) break
+  }
+
+  session.anatomy_hits = (session.anatomy_hits || 0) + (found ? 1 : 0)
+  session.anatomy_misses = (session.anatomy_misses || 0) + (found ? 0 : 1)
+
+  session.files_read[normalizedFile] = {
+    count: 1,
+    tokens: 0,
+    first_read: new Date().toISOString(),
+  }
+
+  writeJSON(sessionFile, session)
+}

--- a/src/templates/opencode-plugin/pre-write.ts
+++ b/src/templates/opencode-plugin/pre-write.ts
@@ -1,0 +1,105 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { getWolfDir, readMarkdown, normalizePath, readJSON } from "./fs.js"
+
+const STOP_WORDS = new Set([
+  "error", "function", "return", "const", "this", "that", "with", "from",
+  "import", "export", "class", "interface", "type", "undefined", "null",
+  "true", "false", "string", "number", "object", "array", "value",
+  "file", "path", "name", "data", "response", "request", "result",
+  "should", "must", "does", "have", "been", "will", "would", "could",
+  "when", "then", "else", "each", "some", "every", "only",
+])
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text.replace(/[^\w\s]/g, " ").split(/\s+/)
+      .filter(w => w.length > 3 && !STOP_WORDS.has(w.toLowerCase()))
+      .map(w => w.toLowerCase())
+  )
+}
+
+export function handlePreWrite(directory: string, sessionId: string, filePath: string, content: string, oldStr: string, newStr: string): void {
+  const wolfDir = getWolfDir(directory)
+  if (!fs.existsSync(wolfDir)) return
+
+  const allContent = [content, oldStr, newStr].join("\n")
+  if (!allContent.trim()) return
+
+  checkCerebrum(wolfDir, allContent)
+
+  if (filePath && (oldStr || content)) {
+    checkBugLog(wolfDir, filePath, oldStr, newStr, content)
+  }
+}
+
+function checkCerebrum(wolfDir: string, content: string): void {
+  const cerebrumContent = readMarkdown(path.join(wolfDir, "cerebrum.md"))
+  const doNotRepeatSection = cerebrumContent.split("## Do-Not-Repeat")[1]
+  if (!doNotRepeatSection) return
+
+  const entries = doNotRepeatSection.split("## ")[0]
+  const lines = entries.split("\n").filter((l) => l.trim().startsWith("[") || l.trim().startsWith("-"))
+  for (const line of lines) {
+    const trimmed = line.trim().replace(/^[-*]\s*/, "").replace(/^\[[\d-]+\]\s*/, "")
+    if (!trimmed) continue
+    const patterns: string[] = []
+    const quotedMatches = trimmed.match(/"([^"]+)"/g) || trimmed.match(/'([^']+)'/g) || trimmed.match(/`([^`]+)`/g)
+    if (quotedMatches) {
+      for (const qm of quotedMatches) {
+        patterns.push(qm.replace(/["'`]/g, ""))
+      }
+    }
+    const neverMatch = trimmed.match(/(?:never use|avoid|don't use|do not use)\s+(\w+)/i)
+    if (neverMatch) patterns.push(neverMatch[1])
+    for (const pattern of patterns) {
+      try {
+        const regex = new RegExp(`\\b${pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i")
+        if (regex.test(content)) {
+          console.warn(`⚠️ OpenWolf cerebrum warning: "${trimmed}" — check your code before proceeding.`)
+        }
+      } catch {}
+    }
+  }
+}
+
+interface BugEntry {
+  id: string
+  error_message: string
+  root_cause: string
+  fix: string
+  file: string
+  tags: string[]
+}
+
+function checkBugLog(wolfDir: string, filePath: string, oldStr: string, newStr: string, content: string): void {
+  const bugLogPath = path.join(wolfDir, "buglog.json")
+  if (!fs.existsSync(bugLogPath)) return
+
+  const bugLog = readJSON<{ version: number; bugs: BugEntry[] }>(bugLogPath, { version: 1, bugs: [] })
+  if (bugLog.bugs.length === 0) return
+
+  const basename = path.basename(filePath)
+  const fileMatches = bugLog.bugs.filter((b: BugEntry) => path.basename(b.file) === basename)
+  if (fileMatches.length === 0) return
+
+  const editText = (oldStr + " " + newStr + " " + content).toLowerCase()
+  const editTokens = tokenize(editText)
+
+  const relevant = fileMatches.filter((bug: BugEntry) => {
+    const tagHit = bug.tags.some((t: string) => editText.includes(t.toLowerCase()))
+    if (tagHit) return true
+    const bugTokens = tokenize(bug.error_message + " " + bug.root_cause)
+    const overlap = [...editTokens].filter(t => bugTokens.has(t))
+    return overlap.length >= 3
+  })
+
+  if (relevant.length === 0) return
+
+  console.warn(`📋 OpenWolf buglog: ${relevant.length} past bug(s) found for ${basename} — review for context, do NOT apply blindly:`)
+  for (const bug of relevant.slice(0, 2)) {
+    console.warn(`   [${bug.id}] "${bug.error_message.slice(0, 70)}"`)
+    console.warn(`   Cause: ${bug.root_cause.slice(0, 80)}`)
+    console.warn(`   Fix: ${bug.fix.slice(0, 80)}`)
+  }
+}

--- a/src/templates/opencode-plugin/session.ts
+++ b/src/templates/opencode-plugin/session.ts
@@ -1,0 +1,89 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { getWolfDir, writeJSON, readJSON, appendMarkdown, timeShort, timestamp, readMarkdown } from "./fs.js"
+import type { SessionState } from "./types.js"
+
+const sessions = new Map<string, SessionState>()
+
+export function getSessionState(sessionId: string): SessionState | undefined {
+  return sessions.get(sessionId)
+}
+
+export function setSessionState(sessionId: string, state: SessionState): void {
+  sessions.set(sessionId, state)
+}
+
+export function deleteSession(sessionId: string): void {
+  sessions.delete(sessionId)
+}
+
+export function handleSessionStart(directory: string, sessionId: string): void {
+  const wolfDir = getWolfDir(directory)
+  if (!fs.existsSync(wolfDir)) return
+
+  const hooksDir = path.join(wolfDir, "hooks")
+  fs.mkdirSync(hooksDir, { recursive: true })
+
+  try {
+    const files = fs.readdirSync(wolfDir)
+    for (const f of files) {
+      if (f.endsWith(".tmp")) {
+        try { fs.unlinkSync(path.join(wolfDir, f)) } catch {}
+      }
+    }
+  } catch {}
+
+  const sessionFile = path.join(hooksDir, "_session.json")
+  const state: SessionState = {
+    session_id: sessionId,
+    started: timestamp(),
+    files_read: {},
+    files_written: [],
+    edit_counts: {},
+    anatomy_hits: 0,
+    anatomy_misses: 0,
+    repeated_reads_warned: 0,
+    cerebrum_warnings: 0,
+    stop_count: 0,
+  }
+  sessions.set(sessionId, state)
+  writeJSON(sessionFile, state)
+
+  const memoryPath = path.join(wolfDir, "memory.md")
+  const now = new Date()
+  const header = `\n## Session: ${now.toISOString().slice(0, 10)} ${timeShort()}\n\n| Time | Action | File(s) | Outcome | ~Tokens |\n|------|--------|---------|---------|--------|\n`
+  appendMarkdown(memoryPath, header)
+
+  try {
+    const cerebrumPath = path.join(wolfDir, "cerebrum.md")
+    const cerebrumContent = fs.readFileSync(cerebrumPath, "utf-8")
+    const stat = fs.statSync(cerebrumPath)
+    const daysSinceUpdate = (Date.now() - stat.mtimeMs) / (1000 * 60 * 60 * 24)
+    const entryLines = cerebrumContent.split("\n").filter(l => {
+      const t = l.trim()
+      return t.startsWith("- ") || t.startsWith("* ") || (t.startsWith("[") && t.includes("]"))
+    })
+    if (entryLines.length < 3) {
+      console.warn(`💡 OpenWolf: cerebrum.md has only ${entryLines.length} entries. Learn from this session — record user preferences, project conventions, and mistakes to .wolf/cerebrum.md.`)
+    } else if (daysSinceUpdate > 3) {
+      console.warn(`💡 OpenWolf: cerebrum.md hasn't been updated in ${Math.floor(daysSinceUpdate)} days. Look for opportunities to add learnings this session.`)
+    }
+  } catch {}
+
+  try {
+    const buglogPath = path.join(wolfDir, "buglog.json")
+    const buglog = readJSON<{ bugs: unknown[] }>(buglogPath, { bugs: [] })
+    if (buglog.bugs.length === 0) {
+      console.warn(`📋 OpenWolf: buglog.json is empty. If you encounter or fix any bugs, errors, or failed tests this session, log them to .wolf/buglog.json.`)
+    }
+  } catch {}
+
+  const ledgerPath = path.join(wolfDir, "token-ledger.json")
+  const ledger = readJSON<Record<string, unknown>>(ledgerPath, { version: 1, lifetime: { total_sessions: 0 } }) as {
+    version: number
+    lifetime: { total_sessions: number }
+    [key: string]: unknown
+  }
+  ledger.lifetime.total_sessions++
+  writeJSON(ledgerPath, ledger)
+}

--- a/src/templates/opencode-plugin/stop.ts
+++ b/src/templates/opencode-plugin/stop.ts
@@ -1,0 +1,126 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { getWolfDir, writeJSON, readJSON, appendMarkdown, timeShort } from "./fs.js"
+import type { SessionState } from "./types.js"
+
+export function handleStop(directory: string, sessionId: string): void {
+  const wolfDir = getWolfDir(directory)
+  if (!fs.existsSync(wolfDir)) return
+
+  const hooksDir = path.join(wolfDir, "hooks")
+  const sessionFile = path.join(hooksDir, "_session.json")
+
+  const session = readJSON<SessionState>(sessionFile, {
+    session_id: "", started: "", files_read: {}, files_written: [],
+    edit_counts: {}, anatomy_hits: 0, anatomy_misses: 0,
+    repeated_reads_warned: 0, cerebrum_warnings: 0, stop_count: 0,
+  })
+
+  session.stop_count++
+
+  const readCount = Object.keys(session.files_read).length
+  const writeCount = session.files_written.length
+
+  if (readCount === 0 && writeCount === 0) {
+    writeJSON(sessionFile, session)
+    return
+  }
+
+  checkForMissingBugLogs(session)
+  buildLedgerEntry(wolfDir, session)
+  appendSessionSummary(wolfDir, session, readCount, writeCount)
+
+  writeJSON(sessionFile, session)
+}
+
+function checkForMissingBugLogs(session: SessionState): void {
+  if (!session.edit_counts) return
+
+  const multiEditFiles = Object.entries(session.edit_counts)
+    .filter(([, count]) => count >= 3)
+    .map(([file]) => path.basename(file))
+
+  if (multiEditFiles.length > 0) {
+    const buglogWritten = session.files_written.some(w => w.file.includes("buglog.json"))
+    if (!buglogWritten) {
+      console.warn(`⚠️ OpenWolf: Files edited 3+ times this session (${multiEditFiles.join(", ")}) but buglog.json was not updated. If you fixed bugs, please log them.`)
+    }
+  }
+}
+
+function buildLedgerEntry(wolfDir: string, session: SessionState): void {
+  const readCount = Object.keys(session.files_read).length
+  const writeCount = session.files_written.length
+
+  const reads = Object.entries(session.files_read).map(([file, data]) => ({
+    file,
+    tokens_estimated: data.tokens,
+    was_repeated: data.count > 1,
+    anatomy_had_description: false,
+  }))
+
+  const writes = session.files_written.map((w) => ({
+    file: w.file,
+    tokens_estimated: w.tokens,
+    action: w.action,
+  }))
+
+  const inputTokens = reads.reduce((sum, r) => sum + r.tokens_estimated, 0)
+  const outputTokens = writes.reduce((sum, w) => sum + w.tokens_estimated, 0)
+
+  const ledgerPath = path.join(wolfDir, "token-ledger.json")
+  const ledger = readJSON<Record<string, unknown>>(ledgerPath, {
+    version: 1, created_at: "", lifetime: { total_tokens_estimated: 0, total_reads: 0, total_writes: 0, total_sessions: 0, anatomy_hits: 0, anatomy_misses: 0, repeated_reads_blocked: 0, estimated_savings_vs_bare_cli: 0 },
+    sessions: [] as Array<{ id: string; started: string; ended: string; reads: unknown[]; writes: unknown[]; totals: Record<string, number> }>,
+    daemon_usage: [], waste_flags: [], optimization_report: { last_generated: null, patterns: [] },
+  }) as {
+    version: number
+    lifetime: Record<string, number>
+    sessions: Array<{ id: string; started: string; ended: string; reads: unknown[]; writes: unknown[]; totals: Record<string, number> }>
+    [key: string]: unknown
+  }
+
+  ledger.sessions.push({
+    id: session.session_id,
+    started: session.started,
+    ended: new Date().toISOString(),
+    reads,
+    writes,
+    totals: {
+      input_tokens_estimated: inputTokens,
+      output_tokens_estimated: outputTokens,
+      reads_count: readCount,
+      writes_count: writeCount,
+      repeated_reads_blocked: session.repeated_reads_warned,
+      anatomy_lookups: session.anatomy_hits,
+    },
+  })
+
+  ledger.lifetime.total_reads += readCount
+  ledger.lifetime.total_writes += writeCount
+  ledger.lifetime.total_tokens_estimated += inputTokens + outputTokens
+  ledger.lifetime.anatomy_hits += session.anatomy_hits
+  ledger.lifetime.anatomy_misses += session.anatomy_misses
+  ledger.lifetime.repeated_reads_blocked += session.repeated_reads_warned
+
+  const savedFromAnatomy = session.anatomy_hits * 200
+  const savedFromRepeats = Object.values(session.files_read)
+    .filter((r) => r.count > 1)
+    .reduce((sum, r) => sum + r.tokens * (r.count - 1), 0)
+  ledger.lifetime.estimated_savings_vs_bare_cli += savedFromAnatomy + savedFromRepeats
+
+  writeJSON(ledgerPath, ledger)
+}
+
+function appendSessionSummary(wolfDir: string, session: SessionState, readCount: number, writeCount: number): void {
+  if (writeCount > 0) {
+    try {
+      const inputTokens = Object.values(session.files_read).reduce((sum, r) => sum + r.tokens, 0)
+      const outputTokens = session.files_written.reduce((sum, w) => sum + w.tokens, 0)
+      const uniqueFiles = new Set(session.files_written.map(w => path.basename(w.file)))
+      const fileList = [...uniqueFiles].slice(0, 5).join(", ")
+      const memoryPath = path.join(wolfDir, "memory.md")
+      appendMarkdown(memoryPath, `| ${timeShort()} | Session end: ${writeCount} writes across ${uniqueFiles.size} files (${fileList}) | ${readCount} reads | ~${inputTokens + outputTokens} tok |\n`)
+    } catch {}
+  }
+}

--- a/src/templates/opencode-plugin/types.ts
+++ b/src/templates/opencode-plugin/types.ts
@@ -1,0 +1,41 @@
+export interface FileRead {
+  count: number
+  tokens: number
+  first_read: string
+}
+
+export interface FileWrite {
+  file: string
+  action: string
+  tokens: number
+  at: string
+}
+
+export interface SessionState {
+  session_id: string
+  started: string
+  files_read: Record<string, FileRead>
+  files_written: FileWrite[]
+  edit_counts: Record<string, number>
+  anatomy_hits: number
+  anatomy_misses: number
+  repeated_reads_warned: number
+  cerebrum_warnings: number
+  stop_count: number
+}
+
+export type PartialSessionState = Partial<SessionState>
+
+export interface FixDetection {
+  category: string
+  summary: string
+  rootCause: string
+  fix: string
+  context?: string
+}
+
+export interface AnatomyEntry {
+  file: string
+  description: string
+  tokens: number
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "sourceMap": true
   },
   "include": ["bin/**/*.ts", "src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "src/dashboard/app"]
+  "exclude": ["node_modules", "dist", "src/dashboard/app", "src/templates/opencode-plugin"]
 }


### PR DESCRIPTION
## Summary

Add OpenCode plugin support to OpenWolf via a new `--opencode` flag on `openwolf init`.

- Creates OpenCode plugin at `.opencode/plugin/openwolf.ts`
- Maps OpenCode's native hooks to OpenWolf's `.wolf/` infrastructure
- Injects OpenWolf protocol into OpenCode's system prompt via `experimental.chat.system.transform`

## Changes

| File | Change |
|---|---|
| `src/cli/init.ts` | Add `initOpenCode()` function, `--opencode` option handling |
| `src/cli/index.ts` | Register `--opencode` CLI option |
| `src/hooks/shared.ts` | Add `projectDir` param to `getWolfDir()`, new `wolfDirExists()` |
| `tsconfig.json` | Exclude `src/templates/*.ts` from compilation |
| `src/templates/opencode-plugin.ts` | OpenCode plugin implementation |
| `src/templates/opencode-md-snippet.md` | Template for opencode.md injection |

## Usage

```bash
openwolf init --opencode
```

This creates:
- `.wolf/` directory with all OpenWolf infrastructure
- `.opencode/plugin/openwolf.ts` - the plugin
- Updates `opencode.md` with OpenWolf instructions