### PR TITLE
feat: extend scanner language support for mobile dev (stacked on #10)

### DIFF
--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -41,7 +41,7 @@ const BINARY_EXTENSIONS = new Set([
 const CODE_EXTENSIONS = new Set([
   ".ts", ".js", ".tsx", ".jsx", ".py", ".rs", ".go", ".java",
   ".c", ".cpp", ".h", ".css", ".scss", ".sql", ".sh", ".yaml",
-  ".yml", ".json", ".toml", ".xml",
+  ".yml", ".json", ".toml", ".xml", ".dart",
 ]);
 
 const PROSE_EXTENSIONS = new Set([".md", ".txt", ".rst", ".adoc"]);

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -38,10 +38,17 @@ const BINARY_EXTENSIONS = new Set([
   ".lock",
 ]);
 
+// Keep in sync with CODE_EXTS in src/tracker/token-estimator.ts
 const CODE_EXTENSIONS = new Set([
   ".ts", ".js", ".tsx", ".jsx", ".py", ".rs", ".go", ".java",
   ".c", ".cpp", ".h", ".css", ".scss", ".sql", ".sh", ".yaml",
   ".yml", ".json", ".toml", ".xml", ".dart",
+  ".kt", ".kts", ".swift", ".m", ".mm",
+  ".hpp", ".hh", ".cc", ".cxx",
+  ".cs", ".rb", ".php", ".lua",
+  ".vue", ".svelte", ".html", ".htm",
+  ".proto", ".graphql", ".gql", ".tf",
+  ".bash", ".zsh", ".fish",
 ]);
 
 const PROSE_EXTENSIONS = new Set([".md", ".txt", ".rst", ".adoc"]);

--- a/src/tracker/token-estimator.ts
+++ b/src/tracker/token-estimator.ts
@@ -1,9 +1,16 @@
 import * as path from "node:path";
 
+// Keep in sync with CODE_EXTENSIONS in src/scanner/anatomy-scanner.ts
 const CODE_EXTS = new Set([
   ".ts", ".js", ".tsx", ".jsx", ".py", ".rs", ".go", ".java",
   ".c", ".cpp", ".h", ".css", ".scss", ".sql", ".sh", ".yaml",
-  ".yml", ".json", ".toml", ".xml",
+  ".yml", ".json", ".toml", ".xml", ".dart",
+  ".kt", ".kts", ".swift", ".m", ".mm",
+  ".hpp", ".hh", ".cc", ".cxx",
+  ".cs", ".rb", ".php", ".lua",
+  ".vue", ".svelte", ".html", ".htm",
+  ".proto", ".graphql", ".gql", ".tf",
+  ".bash", ".zsh", ".fish",
 ]);
 
 const PROSE_EXTS = new Set([".md", ".txt", ".rst", ".adoc"]);


### PR DESCRIPTION
Hey — this is a stacked follow-up to #10. @levnikmyskin's patch adds `.dart` to `CODE_EXTENSIONS` in `src/scanner/anatomy-scanner.ts:44`; I wanted to extend that to cover the rest of the Flutter toolchain (Kotlin, Swift, ObjC) and a few other common gaps, and fix a small drift issue I spotted in the same area.

This PR is stacked on #10, so the commit history here is @levnikmyskin's unchanged `.dart` commit followed by mine. If #10 merges first, I'll rebase and this diff will shrink to only the net-new additions. If this one lands first, #10 becomes a no-op.

## The context

`CODE_EXTENSIONS` isn't a file-inclusion gate — it only controls which chars-per-token ratio `estimateTokens` uses (3.5 for code, 3.75 fallback, 4.0 for prose). A `.dart` file was already being scanned and written to `anatomy.md` before #10; its token count was just ~7% low because it fell through to the default ratio. Same is true today for `.kt`, `.swift`, `.m`, `.mm`, and plenty of others. Worth flagging in case the framing of "add dart support" made the change sound bigger than it is.

## The drift

There are actually **two** near-identical extension sets in the repo:

1. `CODE_EXTENSIONS` in `src/scanner/anatomy-scanner.ts:41` — used by the anatomy scanner's internal `estimateTokens`.
2. `CODE_EXTS` in `src/tracker/token-estimator.ts:3` — used by the exported `detectContentType()` helper that other parts of the codebase consume.

They drifted apart the moment #10 added `.dart` to the first set only. This PR brings them back in sync (`.dart` is added to `CODE_EXTS` here) and drops a one-line `// Keep in sync with ...` comment above each set so the coupling is visible to the next person who touches either file.

## The additions

Added to **both** sets (`.dart` was already in `CODE_EXTENSIONS` from #10 and is newly added to `CODE_EXTS` here):

- **Flutter toolchain:** `.kt`, `.kts`, `.swift`, `.m`, `.mm`
- **C++ variants:** `.hpp`, `.hh`, `.cc`, `.cxx`
- **Other common languages:** `.cs`, `.rb`, `.php`, `.lua`
- **Web frontend:** `.vue`, `.svelte`, `.html`, `.htm`
- **Schema / infra:** `.proto`, `.graphql`, `.gql`, `.tf`
- **Shell variants:** `.bash`, `.zsh`, `.fish`

No behavioral change beyond the ratio swap — `description-extractor.ts` already handles per-language description extraction for Kotlin, Swift, Dart, Ruby, C#, PHP, etc. via its own `path.extname()` routing, so nothing else needs touching.

## Testing

Environment: macOS Darwin 25.3.0, Node 22, pnpm build pipeline unchanged.

Scratch Flutter layout used for rows 5–6:

    <tmp>/lib/main.dart                                 (285 bytes, stateless MyApp widget)
    <tmp>/android/app/src/main/kotlin/MainActivity.kt   (171 bytes, FlutterActivity subclass)
    <tmp>/ios/Runner/AppDelegate.swift                  (227 bytes, FlutterAppDelegate subclass)

| # | Scenario | Result |
|---|---|---|
| 1 | `pnpm build` | Clean — tsc + hooks + vite dashboard build all green |
| 2 | `node dist/bin/openwolf.js --help` | Prints usage, no errors |
| 3 | `detectContentType("foo.kt" / ".swift" / ".m" / ".mm" / ".dart")` on upstream/main | All return `"mixed"` (falls through to 3.75 ratio) |
| 4 | Same calls on this branch | All return `"code"` (3.5 ratio) |
| 5 | `buildAnatomy()` on scratch Flutter layout, upstream/main | `MainActivity.kt ~46 tok`, `AppDelegate.swift ~61 tok`, `main.dart ~76 tok` |
| 6 | Same on this branch | `MainActivity.kt ~49 tok`, `AppDelegate.swift ~65 tok`, `main.dart ~82 tok` — +6.5%, +6.6%, +7.9% respectively |
| 7 | 660-char Dart sample through `estimateTokens(text, "mixed")` vs `estimateTokens(text, "code")` | 176 → 189 tokens (+7.4%) |
| 8 | `anatomy.md` section/description output on scratch project | Kotlin/Swift/Dart descriptions extracted correctly by the existing `description-extractor.ts` (no change needed there) |

Rows 3 and 5 were captured by temporarily reverting both files to `upstream/main` on the same branch, running the same node one-liners, then restoring.