### PR TITLE
fix: handle CRLF line endings in parseAnatomy

### DIFF
--- a/src/dashboard/app/lib/file-parsers.ts
+++ b/src/dashboard/app/lib/file-parsers.ts
@@ -24,7 +24,8 @@ export function parseAnatomy(content: string): { entries: AnatomyEntry[]; metada
   let currentSection = "";
   let files = 0, hits = 0, misses = 0;
 
-  for (const line of content.split("\n")) {
+  for (const raw of content.split("\n")) {
+    const line = raw.replace(/\r$/, "");
     const metaMatch = line.match(/Files:\s*(\d+).*hits:\s*(\d+).*Misses:\s*(\d+)/i);
     if (metaMatch) {
       files = parseInt(metaMatch[1]);

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -65,7 +65,8 @@ export interface AnatomyEntry {
 export function parseAnatomy(content: string): Map<string, AnatomyEntry[]> {
   const sections = new Map<string, AnatomyEntry[]>();
   let currentSection = "";
-  for (const line of content.split("\n")) {
+  for (const raw of content.split("\n")) {
+    const line = raw.replace(/\r$/, "");
     const sm = line.match(/^## (.+)/);
     if (sm) {
       currentSection = sm[1].trim();

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -183,7 +183,8 @@ export function parseAnatomy(content: string): Map<string, AnatomyEntry[]> {
   const sections = new Map<string, AnatomyEntry[]>();
   let currentSection = "";
 
-  for (const line of content.split("\n")) {
+  for (const raw of content.split("\n")) {
+    const line = raw.replace(/\r$/, "");
     const sectionMatch = line.match(/^## (.+)/);
     if (sectionMatch) {
       currentSection = sectionMatch[1].trim();


### PR DESCRIPTION
## Summary

- On Windows with `core.autocrlf=true`, files checked out from git have CRLF (`\r\n`) line endings
- `parseAnatomy` splits on `\n` but the entry regex uses a `$` anchor, which fails to match when `\r` precedes `\n`
- This causes **all entries to silently drop**, and the post-write hook rewrites `anatomy.md` with empty sections — losing all tracked files
- Strips trailing `\r` from each line before regex matching in all three copies of `parseAnatomy`

## Reproduction

1. On Windows with `git config core.autocrlf true`
2. Commit an `anatomy.md` with entries
3. Check it out (git converts LF → CRLF)
4. Trigger any Write/Edit hook → anatomy.md is rewritten with 0 entries

## Files changed

- `src/hooks/shared.ts` — hook-side parseAnatomy
- `src/scanner/anatomy-scanner.ts` — scanner-side parseAnatomy  
- `src/dashboard/app/lib/file-parsers.ts` — dashboard-side parseAnatomy