### PR TITLE
fix: safe config access with defaults (prevents crash on older .wolf/config.json)

### DIFF
--- a/src/cli/cron-cmd.ts
+++ b/src/cli/cron-cmd.ts
@@ -83,7 +83,7 @@ export async function cronRun(id: string): Promise<void> {
   const config = readJSON<WolfConfig>(path.join(wolfDir, "config.json"), {
     openwolf: { dashboard: { port: 18791 } },
   });
-  const port = config.openwolf.dashboard.port;
+  const port = config.openwolf?.dashboard?.port ?? 18791;
 
   // Try calling the daemon's HTTP endpoint first
   try {

--- a/src/cli/daemon-cmd.ts
+++ b/src/cli/daemon-cmd.ts
@@ -17,7 +17,7 @@ function getDashboardPort(): number {
     path.join(wolfDir, "config.json"),
     { openwolf: { dashboard: { port: 18791 } } }
   );
-  return config.openwolf.dashboard.port;
+  return config.openwolf?.dashboard?.port ?? 18791;
 }
 
 function getPm2Name(): string {

--- a/src/cli/dashboard.ts
+++ b/src/cli/dashboard.ts
@@ -48,7 +48,7 @@ export async function dashboardCommand(): Promise<void> {
     openwolf: { dashboard: { port: 18791 } },
   });
 
-  const port = config.openwolf.dashboard.port;
+  const port = config.openwolf?.dashboard?.port ?? 18791;
   const url = `http://localhost:${port}`;
 
   // Check if daemon is already running on that port

--- a/src/daemon/wolf-daemon.ts
+++ b/src/daemon/wolf-daemon.ts
@@ -34,7 +34,7 @@ const config = readJSON<WolfConfig>(path.join(wolfDir, "config.json"), {
 
 const logger = new Logger(
   path.join(wolfDir, "daemon.log"),
-  config.openwolf.daemon.log_level as "debug" | "info" | "warn" | "error"
+  (config.openwolf?.daemon?.log_level ?? "info") as "debug" | "info" | "warn" | "error"
 );
 
 const startTime = Date.now();
@@ -186,7 +186,7 @@ app.get("/{*path}", (_req, res) => {
 });
 
 // Start HTTP server
-const port = config.openwolf.dashboard.port;
+const port = config.openwolf?.dashboard?.port ?? 18791;
 const server = app.listen(port, () => {
   logger.info(`Dashboard server listening on port ${port}`);
 });
@@ -279,7 +279,7 @@ function handleDashboardCommand(msg: { type: string; task_id?: string }): void {
 
 // Cron engine
 let cronEngine: CronEngine | null = null;
-if (config.openwolf.cron.enabled) {
+if (config.openwolf?.cron?.enabled ?? true) {
   cronEngine = new CronEngine(wolfDir, projectRoot, logger, broadcast);
   cronEngine.start();
 }
@@ -288,7 +288,7 @@ if (config.openwolf.cron.enabled) {
 startFileWatcher(wolfDir, logger, broadcast);
 
 // Health heartbeat
-const heartbeatInterval = config.openwolf.cron.heartbeat_interval_minutes * 60 * 1000;
+const heartbeatInterval = (config.openwolf?.cron?.heartbeat_interval_minutes ?? 30) * 60 * 1000;
 const heartbeatTimer = setInterval(() => {
   const statePath = path.join(wolfDir, "cron-state.json");
   const state = readJSON<Record<string, unknown>>(statePath, {});

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -229,8 +229,8 @@ export function buildAnatomy(wolfDir: string, projectRoot: string): { content: s
   walkDir(
     projectRoot,
     projectRoot,
-    config.openwolf.anatomy.exclude_patterns,
-    config.openwolf.anatomy.max_files,
+    config.openwolf?.anatomy?.exclude_patterns ?? ["node_modules", ".git", "dist", "build", ".wolf"],
+    config.openwolf?.anatomy?.max_files ?? 500,
     entries
   );
 


### PR DESCRIPTION
## Summary

Running `openwolf dashboard` (v1.0.4, global install) against an existing `.wolf/config.json` that predates the `dashboard` / `daemon` / `cron` sections crashes immediately:

```
TypeError: Cannot read properties of undefined (reading 'port')
    at Command.dashboardCommand (dist/src/cli/dashboard.js:39:44)
      const port = config.openwolf.dashboard.port;
```

`readJSON`'s fallback is whole-file-only — it returns the fallback object **only** when `fs.readFileSync` / `JSON.parse` throws. When the file exists and parses but is missing a nested section (e.g. any config created before that section was added), every accessor along the chain throws `Cannot read properties of undefined`. The same class of bug exists in 8 places across the CLI, daemon, and scanner.

## Fix

Replace the 8 unsafe accessors with optional chaining + nullish coalescing to sensible defaults — matching the pattern already used in [src/cli/designqc-cmd.ts:33](https://github.com/cytostack/openwolf/blob/main/src/cli/designqc-cmd.ts#L33) (`config.openwolf?.designqc ?? {}`).

Sites changed:
- `src/cli/dashboard.ts:51` — `dashboard.port`
- `src/cli/daemon-cmd.ts:20` — `dashboard.port`
- `src/cli/cron-cmd.ts:86` — `dashboard.port`
- `src/daemon/wolf-daemon.ts:37` — `daemon.log_level`
- `src/daemon/wolf-daemon.ts:189` — `dashboard.port`
- `src/daemon/wolf-daemon.ts:282` — `cron.enabled`
- `src/daemon/wolf-daemon.ts:291` — `cron.heartbeat_interval_minutes`
- `src/scanner/anatomy-scanner.ts:232-233` — `anatomy.exclude_patterns` + `anatomy.max_files`

Defaults mirror the values already present in each call site's `readJSON(..., fallback)` and the canonical `src/templates/config.json`, so behavior is unchanged for callers whose config has the keys.

## Reproduction

```bash
mkdir /tmp/repro && cd /tmp/repro && git init -q
mkdir -p .wolf && cat > .wolf/config.json <<JSON
{ "version": 1, "openwolf": { "enabled": true, "identity": { "adapter": "claude" } } }
JSON
openwolf dashboard
# → TypeError: Cannot read properties of undefined (reading 'port')
```

With this patch the command proceeds, forks the daemon, and serves the dashboard on 18791.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Verified manually against v1.0.4 install: daemon binds 18791, `curl -sI http://127.0.0.1:18791` returns HTTP 200
- [x] Reproduction above no longer crashes

## Notes

Root cause discussion: a broader fix would be to deep-merge the fallback inside `readJSON` itself. That changes library semantics for every caller, so this PR sticks to call-site fixes, matching the pattern already chosen in `designqc-cmd.ts`. Happy to rework as a `readJSON` change if maintainers prefer.