### PR TITLE
fix(readJSON): deep-merge defaults to survive partial configs (alt to #26)

### DIFF
--- a/src/utils/fs-safe.ts
+++ b/src/utils/fs-safe.ts
@@ -2,10 +2,49 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    !Array.isArray(v) &&
+    Object.getPrototypeOf(v) === Object.prototype
+  );
+}
+
+/**
+ * Recursively fills missing keys in `loaded` from `defaults`.
+ * Loaded values always win; defaults only fill gaps. Arrays and scalars
+ * are replaced wholesale (not merged).
+ */
+function deepMergeDefaults<T>(defaults: T, loaded: T): T {
+  if (!isPlainObject(defaults) || !isPlainObject(loaded)) return loaded;
+  const result: Record<string, unknown> = { ...(defaults as Record<string, unknown>) };
+  for (const key of Object.keys(loaded as Record<string, unknown>)) {
+    const lv = (loaded as Record<string, unknown>)[key];
+    const dv = (defaults as Record<string, unknown>)[key];
+    if (isPlainObject(lv) && isPlainObject(dv)) {
+      result[key] = deepMergeDefaults(dv, lv);
+    } else {
+      result[key] = lv;
+    }
+  }
+  return result as T;
+}
+
+/**
+ * Reads JSON from `filePath`. If the file exists and parses, its values are
+ * deep-merged over `fallback` so that missing nested keys fall back to the
+ * provided defaults (loaded values always win). If the file is missing or
+ * unparseable, `fallback` is returned as-is.
+ *
+ * This prevents `TypeError: Cannot read properties of undefined` when a
+ * user's config file predates a section a newer release reads.
+ */
 export function readJSON<T = unknown>(filePath: string, fallback: T): T {
   try {
     const raw = fs.readFileSync(filePath, "utf-8");
-    return JSON.parse(raw) as T;
+    const parsed = JSON.parse(raw) as T;
+    return deepMergeDefaults(fallback, parsed);
   } catch {
     return fallback;
   }


### PR DESCRIPTION
## Summary

**Alternative to #26** — same bug, different fix. Please pick whichever approach you prefer; I'll close the other.

`readJSON`'s fallback is whole-file-only: it's returned only when the file read/parse throws. If `.wolf/config.json` exists and parses but is missing a nested section (any config predating the `dashboard` / `daemon` / `cron` keys), every accessor like `config.openwolf.dashboard.port` throws `TypeError: Cannot read properties of undefined`. There are 9 such unsafe accessors across CLI, daemon, and scanner.

## This PR's approach

Change `readJSON` itself: after a successful parse, deep-merge the loaded value over the caller-supplied `fallback`. Loaded values always win; defaults only fill missing keys. Arrays and scalars are replaced wholesale — only plain objects are merged. File read/parse failure still returns the fallback as-is (unchanged behavior).

**Single-file change**, 40 LoC in [src/utils/fs-safe.ts](https://github.com/cytostack/openwolf/blob/main/src/utils/fs-safe.ts). No call sites touched. Every existing `readJSON(path, fallback)` call becomes tolerant of partial configs for free.

## vs #26

| | #26 (call-site) | This PR (structural) |
|---|---|---|
| Files changed | 5 | 1 |
| LoC delta | +9 / −9 | +40 / −1 |
| Behavior change for callers passing complete configs | none | none |
| Behavior change for callers passing partial configs | crash avoided by explicit `?? default` | crash avoided via merged defaults |
| Future call sites | can still crash if the unsafe pattern creeps back in | automatically safe |
| Risk surface | each call site independent | single helper change affects all readers |

**Pick whichever matches your taste.** #26 is more conservative; this PR is more structural. I'm biased toward this one (one fix instead of N), but I understand the tradeoff.

## Merge semantics (verified)

- User values win at every leaf key
- Defaults fill missing nested sections recursively
- Arrays replaced wholesale (so `exclude_patterns: [...]` doesn't get unioned)
- Missing file → fallback returned untouched (same identity as before)

Ran the compiled `readJSON` against partial configs:

```
merged.openwolf.enabled = true                (user value)
merged.openwolf.identity.adapter = claude     (user value)
merged.openwolf.dashboard.port = 18791        (default fill)
merged.openwolf.daemon.log_level = info       (default fill)
merged.openwolf.cron.enabled = true           (default fill)
missing === defaults ? true                   (untouched fallback)
arr.list = [9,9], arr.extra = kept            (array replace + scalar fill)
```

## Reproduction (same as #26)

```bash
mkdir /tmp/repro && cd /tmp/repro && git init -q
mkdir -p .wolf && cat > .wolf/config.json <<JSON
{ "version": 1, "openwolf": { "enabled": true, "identity": { "adapter": "claude" } } }
JSON
openwolf dashboard
# → TypeError: Cannot read properties of undefined (reading 'port')
```

Post-patch: command succeeds, daemon binds 18791, dashboard serves HTTP 200.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Runtime sanity check on deep-merge semantics (7 cases above)
- [x] Reproduction from #26 no longer crashes
- [ ] Your preference on whether to land this or #26