### PR TITLE
init/update: tag hook entries with `_managedBy: "openwolf"` (fixes #31)

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -55,6 +55,7 @@ const HOOK_SETTINGS = {
             type: "command",
             command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/session-start.js"',
             timeout: 5,
+            _managedBy: "openwolf",
           },
         ],
       },
@@ -67,6 +68,7 @@ const HOOK_SETTINGS = {
             type: "command",
             command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-read.js"',
             timeout: 5,
+            _managedBy: "openwolf",
           },
         ],
       },
@@ -77,6 +79,7 @@ const HOOK_SETTINGS = {
             type: "command",
             command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-write.js"',
             timeout: 5,
+            _managedBy: "openwolf",
           },
         ],
       },
@@ -89,6 +92,7 @@ const HOOK_SETTINGS = {
             type: "command",
             command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-read.js"',
             timeout: 5,
+            _managedBy: "openwolf",
           },
         ],
       },
@@ -99,6 +103,7 @@ const HOOK_SETTINGS = {
             type: "command",
             command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"',
             timeout: 10,
+            _managedBy: "openwolf",
           },
         ],
       },
@@ -111,6 +116,7 @@ const HOOK_SETTINGS = {
             type: "command",
             command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/stop.js"',
             timeout: 10,
+            _managedBy: "openwolf",
           },
         ],
       },
@@ -480,17 +486,22 @@ function replaceOpenWolfHooks(
   if (!merged.hooks) {
     merged.hooks = {};
   }
-  const hooks = merged.hooks as Record<string, Array<{ matcher: string; hooks: Array<{ command?: string; type: string }> }>>;
+  const hooks = merged.hooks as Record<string, Array<{ matcher: string; hooks: Array<{ command?: string; type: string; _managedBy?: string }> }>>;
 
   for (const [event, newMatchers] of Object.entries(hookSettings.hooks)) {
     if (!hooks[event]) {
       hooks[event] = [];
     }
 
-    // Remove any existing OpenWolf hook entries (match by .wolf/hooks/ in command)
+    // Remove any existing OpenWolf hook entries. Prefer the explicit
+    // `_managedBy: "openwolf"` tag, fall back to the legacy
+    // `.wolf/hooks/` substring match so we still clean up entries
+    // installed by versions before the tag existed.
     hooks[event] = hooks[event].filter((entry) => {
       const isOpenWolfHook = entry.hooks?.some(
-        (h) => h.command && h.command.includes(".wolf/hooks/")
+        (h) =>
+          h._managedBy === "openwolf" ||
+          (h.command && h.command.includes(".wolf/hooks/"))
       );
       return !isOpenWolfHook;
     });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -43,18 +43,22 @@ const BACKUP_FILES = [
   ...USER_DATA_FILES,
 ];
 
+// Every hook entry carries `_managedBy: "openwolf"`. Claude Code's
+// settings round-tripper preserves entries with this provenance tag
+// across `/effort`, `/config`, and similar rewrites; untagged entries
+// get silently dropped. See cytostack/openwolf#31.
 const HOOK_SETTINGS = {
   hooks: {
-    SessionStart: [{ matcher: "", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/session-start.js"', timeout: 5 }] }],
+    SessionStart: [{ matcher: "", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/session-start.js"', timeout: 5, _managedBy: "openwolf" }] }],
     PreToolUse: [
-      { matcher: "Read", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-read.js"', timeout: 5 }] },
-      { matcher: "Write|Edit|MultiEdit", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-write.js"', timeout: 5 }] },
+      { matcher: "Read", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-read.js"', timeout: 5, _managedBy: "openwolf" }] },
+      { matcher: "Write|Edit|MultiEdit", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-write.js"', timeout: 5, _managedBy: "openwolf" }] },
     ],
     PostToolUse: [
-      { matcher: "Read", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-read.js"', timeout: 5 }] },
-      { matcher: "Write|Edit|MultiEdit", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"', timeout: 10 }] },
+      { matcher: "Read", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-read.js"', timeout: 5, _managedBy: "openwolf" }] },
+      { matcher: "Write|Edit|MultiEdit", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"', timeout: 10, _managedBy: "openwolf" }] },
     ],
-    Stop: [{ matcher: "", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/stop.js"', timeout: 10 }] }],
+    Stop: [{ matcher: "", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/stop.js"', timeout: 10, _managedBy: "openwolf" }] }],
   },
 };
 
@@ -358,15 +362,20 @@ function replaceOpenWolfHooks(
 ): Record<string, unknown> {
   const merged = { ...existing };
   if (!merged.hooks) merged.hooks = {};
-  const hooks = merged.hooks as Record<string, Array<{ matcher: string; hooks: Array<{ command?: string; type: string }> }>>;
+  const hooks = merged.hooks as Record<string, Array<{ matcher: string; hooks: Array<{ command?: string; type: string; _managedBy?: string }> }>>;
 
   for (const [event, newMatchers] of Object.entries(hookSettings.hooks)) {
     if (!hooks[event]) hooks[event] = [];
 
-    // Remove existing OpenWolf hook entries
+    // Remove existing OpenWolf hook entries. Prefer the explicit
+    // `_managedBy: "openwolf"` tag, fall back to the legacy
+    // `.wolf/hooks/` substring match so we still clean up entries
+    // installed by versions before the tag existed.
     hooks[event] = hooks[event].filter((entry) => {
       const isOpenWolfHook = entry.hooks?.some(
-        (h) => h.command && h.command.includes(".wolf/hooks/")
+        (h) =>
+          h._managedBy === "openwolf" ||
+          (h.command && h.command.includes(".wolf/hooks/"))
       );
       return !isOpenWolfHook;
     });


### PR DESCRIPTION
Fixes #31.

## Why

The 6 hook entries OpenWolf installs into `settings.json` carry no
provenance tag. When Claude Code rewrites `settings.json` as part of
an unrelated command — `/effort`, `/config`, plugin toggling, etc. —
entries that don't carry a `_managedBy` field appear to be dropped
silently. The `.wolf/hooks/*.js` files stay on disk, but Claude Code
stops invoking them.

Reproduced on Linux (Claude Code 2.1.121.cc5) and Windows (2.1.126.a4b)
by running `/effort medium` once after `openwolf init`. Confirmed via
file backup that this is a write of `~/.claude/settings.json` from
Claude Code itself (sibling internal-state files mtimed at the same
instant), and that claude-hooks-tagged entries survive the same write.

## What

1. Tag every hook in `HOOK_SETTINGS` (both `init.ts` and `update.ts`)
   with `_managedBy: "openwolf"`. Same field that claude-hooks uses for
   the same purpose.
2. Tighten `replaceOpenWolfHooks` in both files to match by tag OR by
   `.wolf/hooks/` substring. The substring fallback ensures upgrades
   from pre-tag installs clean up correctly.

The TypeScript change is small (32 insertions, 12 deletions across
two files). `tsc --noEmit` is clean.

## Backward compatibility

- Old installs (no tag): substring fallback still picks them up
  for dedupe, so `openwolf update` cleanly removes the old entries
  and installs the tagged versions.
- New installs: tagged from the start, survive Claude Code rewrites.

## Test plan

- [ ] `openwolf init` in a fresh project — verify the 6 entries land
      in `.claude/settings.json` with `_managedBy: "openwolf"`.
- [ ] In Claude Code, run `/effort high`; confirm the openwolf
      entries are still present afterwards (they were dropped before
      this fix).
- [ ] `openwolf update` on a project with the OLD untagged entries —
      verify they get cleanly replaced with the tagged version (no
      duplicates).