### PR TITLE
fix: preserve per-project config.json (ports) across both init and update

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,7 +7,7 @@ import { scanProject } from "../scanner/anatomy-scanner.js";
 import { readJSON, writeJSON, readText, writeText } from "../utils/fs-safe.js";
 import { ensureDir } from "../utils/paths.js";
 import { isWindows } from "../utils/platform.js";
-import { registerProject } from "./registry.js";
+import { registerProject, getRegisteredProjects } from "./registry.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -23,10 +23,14 @@ function getVersion(): string {
   }
 }
 
-// Files that are safe to overwrite on upgrade (config/protocol, not user data)
+// Files that are safe to overwrite on upgrade (protocol docs only, not user data).
+// NOTE: config.json is deliberately NOT here. It holds per-project port
+// assignments (openwolf.daemon.port / openwolf.dashboard.port) and other
+// user tunables; overwriting it on re-init resets every project to the same
+// default ports (18790 / 18791), so only the first daemon to start can bind
+// and the rest crash-loop on EADDRINUSE. It is handled by reconcileConfig().
 const ALWAYS_OVERWRITE = [
   "OPENWOLF.md",
-  "config.json",
   "reframe-frameworks.md",
 ];
 
@@ -163,6 +167,15 @@ export async function initCommand(): Promise<void> {
       writeTemplateFile(actualTemplatesDir, wolfDir, file);
       createdCount++;
     }
+  }
+
+  // config.json: create-if-missing, and on a fresh create allocate a port
+  // pair that no other registered project is using. Existing configs keep
+  // their ports untouched so a re-init never resets them.
+  if (reconcileConfig(actualTemplatesDir, wolfDir, projectRoot)) {
+    createdCount++;
+  } else {
+    skippedCount++;
   }
 
   // --- Cerebrum: seed project info only if fresh ---
@@ -311,6 +324,60 @@ function writeTemplateFile(templatesDir: string, wolfDir: string, file: string):
   } else {
     generateTemplate(destPath, file);
   }
+}
+
+// Default daemon/dashboard ports. A fresh project is allocated the next free
+// pair so multiple projects' daemons never collide on the same port.
+const DEFAULT_DAEMON_PORT = 18790;
+const DEFAULT_DASHBOARD_PORT = 18791;
+
+function normalizeRoot(p: string): string {
+  const resolved = path.resolve(p);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+// Ports already claimed by OTHER registered projects' config.json files.
+function collectUsedPorts(excludeRoot: string): Set<number> {
+  const used = new Set<number>();
+  const exclude = normalizeRoot(excludeRoot);
+  for (const proj of getRegisteredProjects(false)) {
+    if (normalizeRoot(proj.root) === exclude) continue;
+    const cfg = readJSON<any>(path.join(proj.root, ".wolf", "config.json"), null as any);
+    const ow = cfg && cfg.openwolf;
+    if (ow) {
+      if (ow.daemon && typeof ow.daemon.port === "number") used.add(ow.daemon.port);
+      if (ow.dashboard && typeof ow.dashboard.port === "number") used.add(ow.dashboard.port);
+    }
+  }
+  return used;
+}
+
+// config.json is user data: created from template only when absent, and on
+// that fresh create it is stamped with a port pair no other registered
+// project uses. An existing config is left completely untouched so a re-init
+// never resets its ports. Returns true if a new file was written.
+function reconcileConfig(templatesDir: string, wolfDir: string, projectRoot: string): boolean {
+  const cfgPath = path.join(wolfDir, "config.json");
+  if (fs.existsSync(cfgPath)) {
+    return false; // preserve existing ports + user tunables
+  }
+  writeTemplateFile(templatesDir, wolfDir, "config.json");
+  const cfg = readJSON<any>(cfgPath, null as any);
+  if (cfg && cfg.openwolf && cfg.openwolf.dashboard) {
+    const used = collectUsedPorts(projectRoot);
+    const nextFree = (base: number): number => {
+      let p = base;
+      while (used.has(p)) p++;
+      used.add(p);
+      return p;
+    };
+    cfg.openwolf.daemon = cfg.openwolf.daemon || {};
+    cfg.openwolf.dashboard = cfg.openwolf.dashboard || {};
+    cfg.openwolf.daemon.port = nextFree(DEFAULT_DAEMON_PORT);
+    cfg.openwolf.dashboard.port = nextFree(DEFAULT_DASHBOARD_PORT);
+    writeJSON(cfgPath, cfg);
+  }
+  return true;
 }
 
 function readTemplateContent(filename: string, templatesDir: string): string {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -27,11 +27,21 @@ function getVersion(): string {
   }
 }
 
-// Files that are safe to overwrite (protocol/config)
-const ALWAYS_OVERWRITE = ["OPENWOLF.md", "config.json", "reframe-frameworks.md"];
+// Files that are safe to overwrite (protocol docs only — never user-edited config)
+const ALWAYS_OVERWRITE = ["OPENWOLF.md", "reframe-frameworks.md"];
 
-// Files that contain user data — NEVER overwrite, only create if missing
+// Files that contain user data — NEVER overwrite, only create if missing.
+//
+// `config.json` is user data: it holds per-project port assignments
+// (`openwolf.daemon.port`, `openwolf.dashboard.port`), scan intervals,
+// exclude patterns, and any other tunables a user has customized.
+// Overwriting it on `openwolf update` resets every registered project to
+// the same default ports (18790 / 18791), at which point only the first
+// daemon to start can bind and the rest crash-loop on EADDRINUSE.
+// Keep it in BACKUP_FILES (via the spread below) so `openwolf restore`
+// can still recover it.
 const USER_DATA_FILES = [
+  "config.json",
   "identity.md", "cerebrum.md", "memory.md", "anatomy.md",
   "token-ledger.json", "buglog.json", "cron-manifest.json", "cron-state.json",
   "suggestions.json", "designqc-report.json",


### PR DESCRIPTION
## Problem

On a host with **more than one** OpenWolf project registered, every project's
daemon tries to bind the *same* dashboard port and all but the first
crash-loop on `EADDRINUSE`. Root cause is that `config.json` — which holds the
per-project `openwolf.daemon.port` / `openwolf.dashboard.port` — was being
force-overwritten with the hardcoded template defaults (`18790` / `18791`) by
**both** CLI commands:

1. **`openwolf update`** listed `config.json` in `ALWAYS_OVERWRITE`, so every
   update reset every registered project back to `18790`/`18791`. (Tracked in #37.)
2. **`openwolf init`** *also* listed `config.json` in its own `ALWAYS_OVERWRITE`,
   so any re-init/upgrade reset it too — and there was **no port allocation at
   all**, so even two *fresh* `init`s on the same host produced identical ports.

Observed in the wild: three projects on one host, all stamped `18791`; after a
reboot only the first daemon bound and the other two sat `errored` with
thousands of restart attempts (`EADDRINUSE :::18791`).

## Fix

`config.json` is **user data**, not a template, and is now treated as such in
both commands:

- **`update.ts`** — move `config.json` out of `ALWAYS_OVERWRITE` into
  `USER_DATA_FILES` (still backed up by `restore`). An existing config is never
  overwritten on update.
- **`init.ts`** — remove `config.json` from `ALWAYS_OVERWRITE`; handle it via a
  new `reconcileConfig()`:
  - create-if-missing only — an existing config is left completely untouched, so
    a re-init never resets a user's ports;
  - on a *fresh* create, allocate the next free `daemon`/`dashboard` port pair by
    scanning other registered projects' `config.json`, so two fresh inits no
    longer collide.

No behavior change for single-project users; multi-project hosts stop
colliding. `tsc --noEmit` clean.

## Verification

Deployed the built `init.js` + `update.js` to a live multi-project host and ran
`openwolf update`: all three projects' custom dashboard ports survived
(previously they were reset to `18791`). Output confirms templates updated were
only `OPENWOLF.md, reframe-frameworks.md` — `config.json` untouched.

Closes #37 (and the `init`-side half of the same defect).
