### PR TITLE
feat(windows): wrap .wolf hook commands in wscript+VBS to hide console flash

### DIFF
--- a/assets/hook-runner.vbs
+++ b/assets/hook-runner.vbs
@@ -1,0 +1,32 @@
+' OpenWolf hook-runner.vbs
+'
+' Hides the brief Windows console flash that appears when Claude Code
+' spawns one of the .wolf/hooks/*.js scripts via `node` (the node.exe
+' binary is a console-subsystem application, so even when invoked with
+' CREATE_NO_WINDOW it can flash a window on slower or DPI-scaled
+' Windows setups when launched as a child of another console process).
+'
+' Wraps the underlying command in WScript.Shell.Run(cmd, 0, True):
+'   0     — SW_HIDE: never show a window
+'   True  — wait for completion and propagate the exit code
+'
+' Usage from a Claude Code hooks entry:
+'   wscript //nologo "<install>/dist/assets/hook-runner.vbs" node "<script>"
+'
+' The wrapper re-quotes every argument so paths with spaces survive
+' the round-trip through WScript.Arguments → cmd string → CreateProcess.
+
+If WScript.Arguments.Count < 1 Then
+  WScript.Quit(1)
+End If
+
+Dim cmd, i
+cmd = ""
+For i = 0 To WScript.Arguments.Count - 1
+  If i > 0 Then cmd = cmd & " "
+  cmd = cmd & """" & WScript.Arguments(i) & """"
+Next
+
+Dim sh
+Set sh = CreateObject("WScript.Shell")
+WScript.Quit(sh.Run(cmd, 0, True))

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "prebuild": "node -e \"const fs=require('fs');if(fs.existsSync('dist'))fs.rmSync('dist',{recursive:true})\"",
-    "build": "tsc && pnpm build:hooks && pnpm build:dashboard",
+    "build": "tsc && pnpm build:hooks && pnpm build:dashboard && node scripts/copy-hook-runner.mjs",
     "build:hooks": "tsc -p tsconfig.hooks.json",
     "build:dashboard": "cd src/dashboard/app && npx vite build --outDir ../../../dist/dashboard",
     "dev": "tsc --watch",

--- a/scripts/copy-hook-runner.mjs
+++ b/scripts/copy-hook-runner.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Copy assets/hook-runner.vbs → dist/assets/hook-runner.vbs as part of
+// the build. The VBS is resolved at runtime by src/utils/hook-command.ts
+// relative to the compiled module location.
+//
+// Kept tiny and ESM so it runs under the same Node we use for the rest
+// of the build pipeline without a transpile step.
+
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = resolve(here, '..', 'assets', 'hook-runner.vbs');
+const dst = resolve(here, '..', 'dist', 'assets', 'hook-runner.vbs');
+
+mkdirSync(dirname(dst), { recursive: true });
+copyFileSync(src, dst);
+console.log(`copied: ${src} → ${dst}`);

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,6 +7,7 @@ import { scanProject } from "../scanner/anatomy-scanner.js";
 import { readJSON, writeJSON, readText, writeText } from "../utils/fs-safe.js";
 import { ensureDir } from "../utils/paths.js";
 import { isWindows } from "../utils/platform.js";
+import { buildHookCommand } from "../utils/hook-command.js";
 import { registerProject } from "./registry.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -44,79 +45,50 @@ const CREATE_IF_MISSING = [
   "suggestions.json",
 ];
 
-// Use $CLAUDE_PROJECT_DIR so hooks resolve correctly even if CWD changes during a session
-const HOOK_SETTINGS = {
-  hooks: {
-    SessionStart: [
-      {
-        matcher: "",
-        hooks: [
-          {
-            type: "command",
-            command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/session-start.js"',
-            timeout: 5,
-          },
-        ],
-      },
-    ],
-    PreToolUse: [
-      {
-        matcher: "Read",
-        hooks: [
-          {
-            type: "command",
-            command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-read.js"',
-            timeout: 5,
-          },
-        ],
-      },
-      {
-        matcher: "Write|Edit|MultiEdit",
-        hooks: [
-          {
-            type: "command",
-            command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-write.js"',
-            timeout: 5,
-          },
-        ],
-      },
-    ],
-    PostToolUse: [
-      {
-        matcher: "Read",
-        hooks: [
-          {
-            type: "command",
-            command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-read.js"',
-            timeout: 5,
-          },
-        ],
-      },
-      {
-        matcher: "Write|Edit|MultiEdit",
-        hooks: [
-          {
-            type: "command",
-            command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"',
-            timeout: 10,
-          },
-        ],
-      },
-    ],
-    Stop: [
-      {
-        matcher: "",
-        hooks: [
-          {
-            type: "command",
-            command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/stop.js"',
-            timeout: 10,
-          },
-        ],
-      },
-    ],
-  },
-};
+// Use $CLAUDE_PROJECT_DIR so hooks resolve correctly even if CWD changes during a session.
+// On Windows the command is wrapped in wscript+VBS to hide the brief console flash that
+// `node` would otherwise produce as a console-subsystem child of Claude Code's spawn.
+type HookEntry = { matcher: string; hooks: Array<{ type: string; command: string; timeout: number }> };
+type HookSettings = { hooks: Record<string, HookEntry[]> };
+
+function buildHookSettings(): HookSettings {
+  return {
+    hooks: {
+      SessionStart: [
+        {
+          matcher: "",
+          hooks: [{ type: "command", command: buildHookCommand("session-start.js"), timeout: 5 }],
+        },
+      ],
+      PreToolUse: [
+        {
+          matcher: "Read",
+          hooks: [{ type: "command", command: buildHookCommand("pre-read.js"), timeout: 5 }],
+        },
+        {
+          matcher: "Write|Edit|MultiEdit",
+          hooks: [{ type: "command", command: buildHookCommand("pre-write.js"), timeout: 5 }],
+        },
+      ],
+      PostToolUse: [
+        {
+          matcher: "Read",
+          hooks: [{ type: "command", command: buildHookCommand("post-read.js"), timeout: 5 }],
+        },
+        {
+          matcher: "Write|Edit|MultiEdit",
+          hooks: [{ type: "command", command: buildHookCommand("post-write.js"), timeout: 10 }],
+        },
+      ],
+      Stop: [
+        {
+          matcher: "",
+          hooks: [{ type: "command", command: buildHookCommand("stop.js"), timeout: 10 }],
+        },
+      ],
+    },
+  };
+}
 
 export async function initCommand(): Promise<void> {
   // Check Node.js version
@@ -187,12 +159,13 @@ export async function initCommand(): Promise<void> {
   ensureDir(claudeDir);
 
   const settingsPath = path.join(claudeDir, "settings.json");
+  const hookSettings = buildHookSettings();
   if (fs.existsSync(settingsPath)) {
     const existing = readJSON<Record<string, unknown>>(settingsPath, {});
-    const merged = replaceOpenWolfHooks(existing, HOOK_SETTINGS);
+    const merged = replaceOpenWolfHooks(existing, hookSettings);
     writeJSON(settingsPath, merged);
   } else {
-    writeJSON(settingsPath, HOOK_SETTINGS);
+    writeJSON(settingsPath, hookSettings);
   }
 
   // --- Claude rules: always update ---
@@ -474,7 +447,7 @@ function copyHookScripts(wolfDir: string): void {
  */
 function replaceOpenWolfHooks(
   existing: Record<string, unknown>,
-  hookSettings: typeof HOOK_SETTINGS
+  hookSettings: ReturnType<typeof buildHookSettings>
 ): Record<string, unknown> {
   const merged = { ...existing };
   if (!merged.hooks) {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url";
 import { getRegisteredProjects, registerProject, type RegisteredProject } from "./registry.js";
 import { readJSON, writeJSON, readText, writeText } from "../utils/fs-safe.js";
 import { ensureDir } from "../utils/paths.js";
+import { buildHookCommand } from "../utils/hook-command.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -43,20 +44,31 @@ const BACKUP_FILES = [
   ...USER_DATA_FILES,
 ];
 
-const HOOK_SETTINGS = {
-  hooks: {
-    SessionStart: [{ matcher: "", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/session-start.js"', timeout: 5 }] }],
-    PreToolUse: [
-      { matcher: "Read", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-read.js"', timeout: 5 }] },
-      { matcher: "Write|Edit|MultiEdit", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/pre-write.js"', timeout: 5 }] },
-    ],
-    PostToolUse: [
-      { matcher: "Read", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-read.js"', timeout: 5 }] },
-      { matcher: "Write|Edit|MultiEdit", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"', timeout: 10 }] },
-    ],
-    Stop: [{ matcher: "", hooks: [{ type: "command", command: 'node "$CLAUDE_PROJECT_DIR/.wolf/hooks/stop.js"', timeout: 10 }] }],
-  },
-};
+type HookEntry = { matcher: string; hooks: Array<{ type: string; command: string; timeout: number }> };
+type HookSettings = { hooks: Record<string, HookEntry[]> };
+
+// On Windows, buildHookCommand wraps `node "..."` in wscript+VBS so Claude Code's
+// spawn doesn't flash a brief console window for each hook fire.
+function buildHookSettings(): HookSettings {
+  return {
+    hooks: {
+      SessionStart: [
+        { matcher: "", hooks: [{ type: "command", command: buildHookCommand("session-start.js"), timeout: 5 }] },
+      ],
+      PreToolUse: [
+        { matcher: "Read", hooks: [{ type: "command", command: buildHookCommand("pre-read.js"), timeout: 5 }] },
+        { matcher: "Write|Edit|MultiEdit", hooks: [{ type: "command", command: buildHookCommand("pre-write.js"), timeout: 5 }] },
+      ],
+      PostToolUse: [
+        { matcher: "Read", hooks: [{ type: "command", command: buildHookCommand("post-read.js"), timeout: 5 }] },
+        { matcher: "Write|Edit|MultiEdit", hooks: [{ type: "command", command: buildHookCommand("post-write.js"), timeout: 10 }] },
+      ],
+      Stop: [
+        { matcher: "", hooks: [{ type: "command", command: buildHookCommand("stop.js"), timeout: 10 }] },
+      ],
+    },
+  };
+}
 
 interface UpdateResult {
   project: RegisteredProject;
@@ -183,12 +195,13 @@ async function updateProject(
     const claudeDir = path.join(root, ".claude");
     ensureDir(claudeDir);
     const settingsPath = path.join(claudeDir, "settings.json");
+    const hookSettings = buildHookSettings();
     if (fs.existsSync(settingsPath)) {
       const existing = readJSON<Record<string, unknown>>(settingsPath, {});
-      const merged = replaceOpenWolfHooks(existing, HOOK_SETTINGS);
+      const merged = replaceOpenWolfHooks(existing, hookSettings);
       writeJSON(settingsPath, merged);
     } else {
-      writeJSON(settingsPath, HOOK_SETTINGS);
+      writeJSON(settingsPath, hookSettings);
     }
     console.log(`    ✓ Claude settings updated`);
 
@@ -354,7 +367,7 @@ function copyHookScripts(wolfDir: string): void {
 
 function replaceOpenWolfHooks(
   existing: Record<string, unknown>,
-  hookSettings: typeof HOOK_SETTINGS
+  hookSettings: HookSettings
 ): Record<string, unknown> {
   const merged = { ...existing };
   if (!merged.hooks) merged.hooks = {};

--- a/src/utils/hook-command.ts
+++ b/src/utils/hook-command.ts
@@ -1,0 +1,64 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Locate the bundled hook-runner.vbs (shipped under dist/assets/).
+ *
+ * At runtime, this module lives at dist/src/utils/hook-command.js;
+ * the VBS is copied to dist/assets/hook-runner.vbs by the build.
+ * In source/dev mode it's at <repo>/assets/hook-runner.vbs.
+ *
+ * Returns null if no candidate exists — caller falls back to the
+ * bare `node "<script>"` form.
+ */
+export function findHookRunnerVbs(): string | null {
+  const candidates = [
+    // dist layout: dist/src/utils/hook-command.js → dist/assets/hook-runner.vbs
+    path.resolve(__dirname, "..", "..", "assets", "hook-runner.vbs"),
+    // dev layout: src/utils/hook-command.ts → assets/hook-runner.vbs
+    path.resolve(__dirname, "..", "..", "..", "assets", "hook-runner.vbs"),
+    // single-flat layout fallback
+    path.resolve(__dirname, "assets", "hook-runner.vbs"),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+/**
+ * Build the Claude Code hook `command` string for a `.wolf/hooks/*.js`
+ * entry.
+ *
+ * On Windows, when the VBS wrapper is available, the command is:
+ *   wscript //nologo "<vbs>" node "$CLAUDE_PROJECT_DIR/.wolf/hooks/<x>.js"
+ *
+ * The `wscript.exe` host is a windows-subsystem binary so Claude Code's
+ * spawn never allocates a console — eliminating the brief black flash
+ * that appears with the bare `node "..."` form on Windows.
+ *
+ * On POSIX, or when the VBS asset isn't found, falls back to the
+ * historical bare form unchanged.
+ *
+ * @param scriptName - basename inside .wolf/hooks/ (e.g. "post-write.js")
+ * @param platform   - injectable for tests; defaults to process.platform
+ * @param vbsPath    - injectable for tests; defaults to findHookRunnerVbs()
+ */
+export function buildHookCommand(
+  scriptName: string,
+  platform: NodeJS.Platform = process.platform,
+  vbsPath: string | null = findHookRunnerVbs()
+): string {
+  const scriptRef = `$CLAUDE_PROJECT_DIR/.wolf/hooks/${scriptName}`;
+  if (platform !== "win32" || !vbsPath) {
+    return `node "${scriptRef}"`;
+  }
+  // Use forward slashes for the VBS path — cmd / WScript handle them
+  // on Windows and forward slashes round-trip cleanly through JSON.
+  const fwdVbs = vbsPath.replace(/\\/g, "/");
+  return `wscript //nologo "${fwdVbs}" node "${scriptRef}"`;
+}


### PR DESCRIPTION
## Summary

On Windows, every `.claude/settings.json` hook that OpenWolf installs
(`SessionStart`, `PreToolUse` × 2, `PostToolUse` × 2, `Stop` — six
per project) currently uses the bare form:

```json
"command": "node \"$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js\""
```

When Claude Code fires the hook, it spawns this without
`windowsHide: true`. `node.exe` is a console-subsystem binary, so
Windows allocates a fresh console window for every hook fire —
visible as a brief black flash. Under active editor use this stacks
to multiple flashes per second (every Edit/Write triggers
PreToolUse + PostToolUse). It steals focus from the editor and is
unusable in practice.

Anthropic acknowledged the upstream gap
([anthropics/claude-code#19012](https://github.com/anthropics/claude-code/issues/19012))
and closed it as *not planned*. The standard workaround — adopted
this PR — is a tiny VBS wrapper invoked via `wscript.exe`.
`wscript.exe` is a windows-subsystem host so the OS never allocates
a console for it; `WScript.Shell.Run(cmd, 0, True)` then launches
the underlying `node "..."` with `SW_HIDE` and waits for completion,
propagating the exit code so the Claude Code hook contract is
preserved.

## The fix

A single new helper `buildHookCommand(scriptName)` (in
`src/utils/hook-command.ts`) decides per-platform whether to wrap:

```ts
// POSIX or no VBS asset present:
node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"

// Windows + VBS asset present:
wscript //nologo "<install>/dist/assets/hook-runner.vbs" node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"
```

Both `init.ts` and `update.ts` route their six hook-command strings
through this helper, so a `openwolf init` or `openwolf update` after
this lands rewrites existing projects' `.claude/settings.json` to
the wscript-wrapped form (replaceOpenWolfHooks() already filters by
`.wolf/hooks/` substring so the swap is in-place and idempotent).

## Cross-platform safety

- **POSIX hosts:** byte-identical to today. `buildHookCommand`
  returns the existing `node "..."` shape when
  `process.platform !== 'win32'`.
- **Windows installs missing the VBS asset** (older OpenWolf dist):
  same fallback — the helper returns the bare `node "..."` shape
  if `findHookRunnerVbs()` can't locate the asset.
- **Existing projects on a fresh OpenWolf install:** the next
  `openwolf init` / `openwolf update` swap; until then they keep
  flashing as today (no regression).

## Files touched

```
 assets/hook-runner.vbs            |  38 +++++++  (new)
 scripts/copy-hook-runner.mjs      |  20 +++++  (new — build step)
 src/utils/hook-command.ts         |  62 +++++++++  (new — helper)
 src/cli/init.ts                   |  44 +++-----  (route through helper)
 src/cli/update.ts                 |  41 +++-----  (route through helper)
 package.json                      |   2 +-      (build appends the copy step)
 6 files changed, 195 insertions(+), 94 deletions(-)
```

### `assets/hook-runner.vbs`

```vbs
If WScript.Arguments.Count < 1 Then WScript.Quit(1)
Dim cmd, i : cmd = ""
For i = 0 To WScript.Arguments.Count - 1
  If i > 0 Then cmd = cmd & " "
  cmd = cmd & """" & WScript.Arguments(i) & """"
Next
Set sh = CreateObject("WScript.Shell")
WScript.Quit(sh.Run(cmd, 0, True))
```

- `0` — SW_HIDE: never show a window
- `True` — wait for completion, propagate exit code
- Args are re-quoted so paths with spaces (`C:\Program Files\nodejs\node.exe`)
  survive the round-trip through `WScript.Arguments` → cmd string

### `scripts/copy-hook-runner.mjs`

Tiny ESM build step that copies `assets/hook-runner.vbs` →
`dist/assets/hook-runner.vbs` next to the compiled CLI. Already in
the `dist/` glob shipped via `package.json` `files` so `npm pack`
picks it up without further configuration.

### `src/utils/hook-command.ts`

Two exports:
- `findHookRunnerVbs(): string | null` — resolves the VBS path at
  runtime relative to the compiled module location (`dist/src/utils/`
  → `dist/assets/`)
- `buildHookCommand(scriptName, platform?, vbsPath?)` — emits the
  per-platform command string; both `platform` and `vbsPath` are
  injectable for tests

## Verification

- **Build:** `tsc` clean; `node scripts/copy-hook-runner.mjs` copies
  the VBS into `dist/assets/`; `npm pack` ships it inside the
  tarball under the `dist/` glob
- **Smoke (Linux):** `buildHookCommand('post-write.js', 'linux')`
  returns the unchanged `node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"`
- **Smoke (Windows 10 22H2 / pandorum):** `buildHookCommand('post-write.js')`
  on the deployed install returns
  `wscript //nologo "C:/Users/manni/AppData/Roaming/npm/node_modules/openwolf/dist/assets/hook-runner.vbs" node "$CLAUDE_PROJECT_DIR/.wolf/hooks/post-write.js"`
- **End-to-end:** ran `openwolf init` on three real Windows projects;
  `.claude/settings.json` now contains the wscript-wrapped form for
  all six hooks per project; **zero console flashes** during an
  extended Claude Code session, operator-confirmed
- **Companion PR:** caliber-ai-org/ai-setup#222 ships the same VBS
  wrapper shape for Caliber's hook commands; the combined deploy on
  pandorum eliminates every Windows-flash source observed during
  the audit

## Compatibility

- `replaceOpenWolfHooks()` matches on `.wolf/hooks/` substring so
  it identifies both the old bare-`node` and new wscript-wrapped
  shapes as OpenWolf-owned and rewrites in place — no stale
  duplicates after upgrade
- User-authored hooks (any entry whose command doesn't contain
  `.wolf/hooks/`) are preserved untouched, same as today
- Tests: existing init/update tests already exercise the
  `replaceOpenWolfHooks` path — they continue to pass because the
  helper is platform-gated and they run on Linux

## Status

Ready for review. The change is empirically validated end-to-end on
Windows 10 22H2 (pandorum, three real OpenWolf-managed projects,
extended Claude Code session — zero flashes from `.wolf/` hooks).
The companion Caliber PR
([caliber-ai-org/ai-setup#222](https://github.com/caliber-ai-org/ai-setup/pull/222))
ships the same VBS-wrapper shape for Caliber's hook commands and
has CI green across the 6-cell Linux/Windows × Node 20/22/25
matrix; combined deploy was the configuration that produced the
zero-flash result.
