### PR TITLE
fix(buglog): make `bug search` null-safe across schema drift

### DIFF
--- a/src/buglog/bug-tracker.ts
+++ b/src/buglog/bug-tracker.ts
@@ -5,7 +5,8 @@ interface BugEntry {
   id: string;
   timestamp: string;
   error_message: string;
-  file: string;
+  file?: string;
+  files?: string[];
   line?: number;
   root_cause: string;
   fix: string;
@@ -124,12 +125,19 @@ export function findSimilarBugs(wolfDir: string, errorMessage: string): ScoredBu
 export function searchBugs(wolfDir: string, term: string): BugEntry[] {
   const bugLog = readBugLog(wolfDir);
   const lower = term.toLowerCase();
+  // Null-safe across schema drift: older entries omit `file`/`tags`, newer
+  // ones use a `files` array instead of a singular `file`. A missing field on
+  // any one entry must skip that entry, not throw and abort the whole search.
+  const has = (s: unknown): boolean =>
+    typeof s === "string" && s.toLowerCase().includes(lower);
+  const hasAny = (a: unknown): boolean => Array.isArray(a) && a.some(has);
   return bugLog.bugs.filter(
     (b) =>
-      b.error_message.toLowerCase().includes(lower) ||
-      b.root_cause.toLowerCase().includes(lower) ||
-      b.fix.toLowerCase().includes(lower) ||
-      b.tags.some((t) => t.toLowerCase().includes(lower)) ||
-      b.file.toLowerCase().includes(lower)
+      has(b.error_message) ||
+      has(b.root_cause) ||
+      has(b.fix) ||
+      hasAny(b.tags) ||
+      has(b.file) ||
+      hasAny(b.files)
   );
 }


### PR DESCRIPTION
## Problem

`openwolf bug search <term>` crashes with a `TypeError` on any buglog that contains an entry missing one of the fields `searchBugs` assumes are always present:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at .../dist/src/buglog/bug-tracker.js:79   // b.file.toLowerCase()
```

`searchBugs` does `b.error_message.toLowerCase()`, `b.tags.some(...)`, `b.file.toLowerCase()` etc. with no null-guard. Real-world buglogs drift over time:

- Older entries omit `file` and/or `tags`.
- Some tooling records a `files: string[]` array instead of a singular `file`.

A **single** such entry anywhere in the array makes the `.filter()` callback throw, which aborts the **entire** search — so one legacy entry breaks `bug search` for the whole project. (Hit this on a 1900+ entry buglog where ~28 `audit-finding-*` entries had no `file` key.)

## Fix

Make the search field-access null-safe and tolerant of the `files` array:

- A `has(s)` helper (`typeof s === "string" && …`) and `hasAny(a)` (`Array.isArray(a) && a.some(has)`) so a missing/wrong-typed field on one entry **skips that entry** instead of crashing the whole search.
- Also search the `files` array; added `files?: string[]` to `BugEntry` and made `file` optional to match real-world data.

No behavioural change for well-formed entries; only previously-crashing inputs now search cleanly.

## Verification

- `pnpm exec tsc --noEmit` → **0 errors**.
- Functional test over a mixed-schema buglog (one entry missing `file`, one with a `files` array, one normal):
  - `search "legacy"` → matches the **missing-`file`** entry (previously crashed) ✓
  - `search "<a files path>"` → matches via the **`files` array** ✓
  - `search "<a file path>"` → matches via singular **`file`** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
