### PR TITLE
fix: parseAnatomy tolerates CRLF line endings (fixes #50)

### DIFF
--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -65,7 +65,11 @@ export interface AnatomyEntry {
 export function parseAnatomy(content: string): Map<string, AnatomyEntry[]> {
   const sections = new Map<string, AnatomyEntry[]>();
   let currentSection = "";
-  for (const line of content.split("\n")) {
+  // Split on \r?\n: with CRLF endings (e.g. git autocrlf=true rewriting the
+  // file on checkout) every entry line ends in \r, the $-anchored entry
+  // regex below matches nothing, and the post-write rewrite then drops
+  // every entry — truncating anatomy.md to an empty skeleton.
+  for (const line of content.split(/\r?\n/)) {
     const sm = line.match(/^## (.+)/);
     if (sm) {
       currentSection = sm[1].trim();

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -183,7 +183,11 @@ export function parseAnatomy(content: string): Map<string, AnatomyEntry[]> {
   const sections = new Map<string, AnatomyEntry[]>();
   let currentSection = "";
 
-  for (const line of content.split("\n")) {
+  // Split on \r?\n: with CRLF endings (e.g. git autocrlf=true rewriting the
+  // file on checkout) every entry line ends in \r, the $-anchored entry
+  // regex below matches nothing, and a parse→rewrite cycle then drops
+  // every entry — truncating anatomy.md to an empty skeleton.
+  for (const line of content.split(/\r?\n/)) {
     const sectionMatch = line.match(/^## (.+)/);
     if (sectionMatch) {
       currentSection = sectionMatch[1].trim();


### PR DESCRIPTION
Fixes #50.

`parseAnatomy` split on plain `"\n"`, so with CRLF line endings (e.g. git `core.autocrlf=true` rewriting `.wolf/anatomy.md` on checkout — a common Windows default) every entry line ends in `\r` and the $-anchored entry regex matches nothing. The post-write hook's parse→rewrite cycle then drops every entry, truncating anatomy.md to an empty skeleton ("Files: 1 tracked", sections kept, entries gone).

This PR changes the split to `/\r?\n/` in both `parseAnatomy` copies (`src/hooks/shared.ts` and `src/scanner/anatomy-scanner.ts`). `serializeAnatomy` already writes LF, so one pass renormalizes a poisoned file; no other behavior changes.

Verified against the live failure: with the patched parser, driving the post-write hook on a CRLF-converted anatomy.md preserves 161/161 entries (pre-patch it collapsed to 1). Full repro steps in #50.