### PR TITLE
feat: add Codex App hook adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">OpenWolf</h1>
 
 <p align="center">
-  <strong>A second brain for Claude Code.</strong><br />
+  <strong>A second brain for Claude Code and Codex App.</strong><br />
   Project intelligence, token tracking, and invisible enforcement through 6 hook scripts. Zero workflow changes.
 </p>
 
@@ -19,9 +19,9 @@
 
 ## Why OpenWolf Exists
 
-Claude Code is powerful but it works blind. It doesn't know what a file contains until it opens it. It can't tell a 50-token config from a 2,000-token module. It reads the same file multiple times in one session without noticing. It has no index of your project, no memory of your corrections, and no awareness of what it already tried.
+Claude Code and Codex App are powerful, but they work blind. They don't know what a file contains until they open it. They can't tell a 50-token config from a 2,000-token module. They can read the same file multiple times in one session without noticing. They have no index of your project, no memory of your corrections, and no awareness of what they already tried.
 
-OpenWolf gives Claude a second brain: a file index so it knows what files contain before reading them, a learning memory that accumulates your preferences and past mistakes, and a token ledger that tracks everything. All through 6 invisible hook scripts that fire on every Claude action.
+OpenWolf gives your coding agent a second brain: a file index so it knows what files contain before reading them, a learning memory that accumulates your preferences and past mistakes, and a token ledger that tracks everything. Claude Code uses the project hooks directly; Codex App uses an adapter installed into its global hook file.
 
 ## Token Comparison
 
@@ -45,7 +45,7 @@ cd your-project
 openwolf init
 ```
 
-That's it. Use `claude` normally. OpenWolf is watching.
+That's it. Use `claude` or Codex App normally. OpenWolf is watching.
 
 ## What It Creates
 
@@ -58,7 +58,7 @@ That's it. Use `claude` normally. OpenWolf is watching.
 | `memory.md` | Chronological action log with token estimates |
 | `buglog.json` | Bug fix memory, searchable, prevents re-discovery |
 | `token-ledger.json` | Lifetime token tracking and session history |
-| `hooks/` | 6 Claude Code lifecycle hooks (pure Node.js) |
+| `hooks/` | 6 lifecycle hooks (pure Node.js) |
 | `config.json` | Configuration with sensible defaults |
 | `identity.md` | Agent persona for this project |
 | `OPENWOLF.md` | Instructions Claude follows every session |
@@ -66,6 +66,8 @@ That's it. Use `claude` normally. OpenWolf is watching.
 ## How It Works
 
 Before Claude reads a file, OpenWolf tells it what the file contains and how large it is. If Claude already read that file this session, OpenWolf warns it. Before Claude writes code, OpenWolf checks your `cerebrum.md` for known mistakes. After every write, it auto-updates the project map and logs token usage. You see none of this. It just happens.
+
+In Codex App, `openwolf init` also installs `~/.codex/hooks/openwolf_codex_hook.mjs` and merges OpenWolf entries into `~/.codex/hooks.json`. The adapter maps Codex tools such as `functions.apply_patch`, `functions.shell_command`, and `multi_tool_use.parallel` into the same OpenWolf hook payloads used by Claude Code.
 
 ```
 You type a message
@@ -212,19 +214,19 @@ Ask Claude to help you pick a UI framework. OpenWolf ships a curated knowledge b
 
 ## How OpenWolf Compares
 
-OpenWolf is not an AI wrapper. It is 6 hook scripts and a `.wolf/` directory. It doesn't run your AI for you or change your workflow. It gives Claude Code what it lacks: a project map so it reads less, a memory so it learns faster, and a ledger so you see where tokens go.
+OpenWolf is not an AI wrapper. It is 6 hook scripts, a Codex App adapter, and a `.wolf/` directory. It doesn't run your AI for you or change your workflow. It gives coding agents what they lack: a project map so they read less, a memory so they learn faster, and a ledger so you see where tokens go.
 
 ## Requirements
 
 - Node.js 20+
-- Claude Code CLI
+- Claude Code CLI or Codex App
 - Windows, macOS, or Linux
 - Optional: PM2 for persistent background tasks
 - Optional: `puppeteer-core` for Design QC screenshots
 
 ## Limitations
 
-- Claude Code hooks are a relatively new feature. OpenWolf falls back to `CLAUDE.md` instructions when hooks don't fire.
+- Claude Code and Codex App hooks are relatively new. Run `openwolf status` to verify both hook registrations.
 - Token tracking is estimation-based (character-to-token ratio), not exact API counts. Accurate to within ~15%.
 - `cerebrum.md` depends on Claude following instructions to update it after corrections. Compliance is ~85-90%, not 100%.
 - This is v1.0.4. Things may break. [File issues](https://github.com/cytostack/openwolf/issues).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,15 +15,16 @@ openwolf init
 2. Creates `.wolf/` with 10 template files
 3. Copies 7 hook scripts to `.wolf/hooks/`
 4. Registers 6 Claude Code hooks in `.claude/settings.json`
-5. Creates `.claude/rules/openwolf.md`
-6. Prepends the OpenWolf snippet to `CLAUDE.md`
-7. Runs an initial anatomy scan
-8. Populates `cerebrum.md` with detected project name and description
+5. Installs Codex App adapter hooks in `~/.codex/hooks.json`
+6. Creates `.claude/rules/openwolf.md`
+7. Prepends the OpenWolf snippet to `CLAUDE.md`
+8. Runs an initial anatomy scan
+9. Populates `cerebrum.md` with detected project name and description
 
 If `.wolf/` already exists, it reinitializes (overwrites templates, preserves learned data).
 
 ::: info
-If `.claude/settings.json` already has hooks, OpenWolf merges its hooks in -- existing hooks are not overwritten.
+If `.claude/settings.json` or `~/.codex/hooks.json` already has hooks, OpenWolf merges its hooks in -- existing hooks are not overwritten.
 :::
 
 ---
@@ -44,6 +45,7 @@ OpenWolf Status
   ✓ All 10 core files present
   ✓ All 7 hook scripts present
   ✓ Claude Code hooks registered (6 matchers)
+  ✓ Codex App hooks registered (6 hooks)
 
 Token Stats:
   Sessions: 12

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- **Node.js 20+** -- [download](https://nodejs.org). Required even if you installed Claude Code via the native installer, because OpenWolf's hooks run as Node.js scripts.
-- **Claude Code** -- OpenWolf is middleware for Claude Code. Any installation method works: native installer, npm, Homebrew, or WinGet. The Claude Code desktop app is also supported.
+- **Node.js 20+** -- [download](https://nodejs.org). Required because OpenWolf's hooks run as Node.js scripts.
+- **Claude Code or Codex App** -- OpenWolf supports Claude Code project hooks and Codex App global hooks.
 
 ## Install OpenWolf
 
@@ -32,15 +32,16 @@ You'll see:
   ✓ OpenWolf initialized
   ✓ .wolf/ created with 11 files
   ✓ Claude Code hooks registered (6 hooks)
+  ✓ Codex App hooks registered (6 hooks)
   ✓ CLAUDE.md updated
   ✓ .claude/rules/openwolf.md created
   ✓ Anatomy scan: 47 files indexed
   ✓ Daemon: start manually with: openwolf daemon start
 
-  You're ready. Just use 'claude' as normal. OpenWolf is watching.
+  You're ready. Use Claude Code or Codex App normally. OpenWolf is watching.
 ```
 
-That's it. No configuration needed. Just use `claude` as you normally would.
+That's it. No configuration needed. Use `claude` or Codex App as you normally would.
 
 ## Verify it's working
 
@@ -55,6 +56,7 @@ OpenWolf Status
   ✓ All 11 core files present
   ✓ All 7 hook scripts present
   ✓ Claude Code hooks registered (6 matchers)
+  ✓ Codex App hooks registered (6 hooks)
 
 Token Stats:
   Sessions: 0
@@ -70,7 +72,7 @@ Daemon: initialized
 
 ## What happens next?
 
-Every time you run `claude` in this project:
+Every time you run Claude Code in this project, or use Codex App with this project open:
 
 1. **Session starts** -- OpenWolf creates a session tracker and logs the start to `memory.md`
 2. **Before file reads** -- the hook checks if the file was already read (warns you) and shows the anatomy description
@@ -80,6 +82,12 @@ Every time you run `claude` in this project:
 6. **On stop** -- session totals are written to the token ledger
 
 You don't interact with any of this. It's invisible.
+
+## Codex App hooks
+
+For Codex App, `openwolf init` writes a small adapter to `~/.codex/hooks/openwolf_codex_hook.mjs` and merges OpenWolf entries into `~/.codex/hooks.json`. Existing Codex hooks are preserved. The adapter translates Codex tool names and payloads into OpenWolf's hook format, including `functions.apply_patch`, `functions.shell_command`, and `multi_tool_use.parallel`.
+
+If Codex App was already open, start a new Codex App session after running `openwolf init` so it reloads the hook configuration.
 
 ## View the dashboard
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,8 +1,14 @@
 # Hooks
 
-OpenWolf registers 6 hooks with Claude Code. They fire automatically on every action. No user interaction required.
+OpenWolf registers 6 hooks with Claude Code and installs a Codex App adapter for the same hook lifecycle. They fire automatically on supported actions. No user interaction required.
 
-All hooks are **pure Node.js file I/O**. No network calls, no AI, no external dependencies. They read JSON on stdin from Claude Code and communicate via exit codes and stderr.
+All hooks are **pure Node.js file I/O**. No network calls, no AI, no external dependencies. They read JSON on stdin and communicate via exit codes and stderr.
+
+## Codex App Adapter
+
+Claude Code reads project-local hook commands from `.claude/settings.json`. Codex App reads global hooks from `~/.codex/hooks.json`, so `openwolf init` also installs `~/.codex/hooks/openwolf_codex_hook.mjs`.
+
+The adapter finds the nearest project containing `.wolf/hooks/`, sets `OPENWOLF_PROJECT_DIR`, `CODEX_PROJECT_DIR`, and `CLAUDE_PROJECT_DIR`, then invokes the same hook scripts listed below. It maps Codex tools like `functions.apply_patch`, `functions.shell_command`, and `multi_tool_use.parallel` into Claude-style `Read`, `Write`, `Edit`, or `MultiEdit` payloads.
 
 ## Hook Lifecycle
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -112,9 +112,9 @@ Or let OpenWolf detect it from your README. The daemon checks (in order):
 
 ## Hooks not firing
 
-**Symptom:** OpenWolf doesn't track tokens or update memory when using Claude.
+**Symptom:** OpenWolf doesn't track tokens or update memory when using Claude Code or Codex App.
 
-**Cause:** Claude Code hooks aren't registered or the hook scripts are missing.
+**Cause:** Claude Code hooks are not registered, Codex App global hooks are not registered, or the hook scripts are missing.
 
 **Fix:** Re-run init to register hooks:
 
@@ -128,7 +128,9 @@ Then verify:
 openwolf status
 ```
 
-Look for `✓ Claude Code hooks registered (6 matchers)`.
+Look for both `✓ Claude Code hooks registered (...)` and `✓ Codex App hooks registered (6 hooks)`.
+
+For Codex App specifically, `openwolf init` installs `~/.codex/hooks/openwolf_codex_hook.mjs` and merges entries into `~/.codex/hooks.json`. Existing Codex hooks are preserved. If Codex App was already open, start a new Codex App session after running `openwolf init` so the app reloads the hook configuration.
 
 ## Anatomy scan finds 0 files
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -25,13 +25,14 @@ openwolf update
    - `reframe-frameworks.md`
    - Hook scripts in `.wolf/hooks/`
    - Claude rules in `.claude/rules/openwolf.md`
+   - Codex App adapter in `~/.codex/hooks/openwolf_codex_hook.mjs`
 3. **Preserves user data** -- these files are never overwritten:
    - `cerebrum.md` (learned preferences and conventions)
    - `memory.md` (session history)
    - `buglog.json` (bug tracking)
    - `anatomy.md` (project file map)
    - Any custom files you added to `.wolf/`
-4. **Updates hooks** registered in `.claude/settings.json`
+4. **Updates hooks** registered in `.claude/settings.json` and `~/.codex/hooks.json`
 
 ### Options
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openwolf",
   "version": "1.0.4",
-  "description": "Token-conscious AI brain for Claude Code projects",
+  "description": "Token-conscious AI brain for Claude Code and Codex App projects",
   "type": "module",
   "bin": {
     "openwolf": "./dist/bin/openwolf.js"
@@ -65,6 +65,8 @@
     "token",
     "openwolf",
     "claude-code",
+    "codex",
+    "codex-app",
     "developer-tools"
   ],
   "files": [

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,7 +25,7 @@ export function createProgram(): Command {
 
   program
     .name("openwolf")
-    .description("Token-conscious AI brain for Claude Code projects")
+    .description("Token-conscious AI brain for Claude Code and Codex App projects")
     .version(getVersion());
 
   program

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -8,6 +8,7 @@ import { readJSON, writeJSON, readText, writeText } from "../utils/fs-safe.js";
 import { ensureDir } from "../utils/paths.js";
 import { isWindows } from "../utils/platform.js";
 import { registerProject } from "./registry.js";
+import { installCodexAppHooks } from "../codex/codex-hooks.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -195,6 +196,16 @@ export async function initCommand(): Promise<void> {
     writeJSON(settingsPath, HOOK_SETTINGS);
   }
 
+  // --- Codex App global hooks: install adapter and register OpenWolf entries ---
+  let codexHookStatus = "not installed";
+  try {
+    const codexHooks = installCodexAppHooks();
+    codexHookStatus = `registered (${codexHooks.entryCount} hooks)`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    codexHookStatus = `not installed (${msg})`;
+  }
+
   // --- Claude rules: always update ---
   const rulesDir = path.join(claudeDir, "rules");
   ensureDir(rulesDir);
@@ -272,19 +283,21 @@ export async function initCommand(): Promise<void> {
     console.log(`  ✓ OpenWolf upgraded to v${version}`);
     console.log(`  ✓ All .wolf data preserved (${skippedCount} files: cerebrum, memory, anatomy, buglog, ledger)`);
     console.log(`  ✓ Hook scripts updated (6 hooks)`);
+    console.log(`  ✓ Codex App hooks ${codexHookStatus}`);
     console.log(`  ✓ ${createdCount} config files updated`);
     console.log(`  ✓ Anatomy: ${fileCount} files tracked (unchanged)`);
   } else {
     console.log(`  ✓ OpenWolf v${version} initialized`);
     console.log(`  ✓ .wolf/ created with ${createdCount} files`);
     console.log(`  ✓ Claude Code hooks registered (6 hooks)`);
+    console.log(`  ✓ Codex App hooks ${codexHookStatus}`);
     console.log(`  ✓ CLAUDE.md updated`);
     console.log(`  ✓ .claude/rules/openwolf.md created`);
     console.log(`  ✓ Anatomy scan: ${fileCount} files indexed`);
   }
   console.log(`  ✓ Daemon: ${daemonStatus}`);
   console.log("");
-  console.log("  You're ready. Just use 'claude' as normal — OpenWolf is watching.");
+  console.log("  You're ready. Use Claude Code or Codex App normally — OpenWolf is watching.");
   console.log("");
 }
 

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { findProjectRoot } from "../scanner/project-root.js";
 import { readJSON, readText } from "../utils/fs-safe.js";
+import { getCodexAppHookStatus } from "../codex/codex-hooks.js";
 
 export async function statusCommand(): Promise<void> {
   const projectRoot = findProjectRoot();
@@ -61,6 +62,16 @@ export async function statusCommand(): Promise<void> {
     }
   } else {
     console.log("  ✗ .claude/settings.json not found");
+  }
+
+  // Codex App global hook check
+  const codexStatus = getCodexAppHookStatus();
+  if (codexStatus.adapterInstalled && codexStatus.missingActions.length === 0) {
+    console.log(`  ✓ Codex App hooks registered (${codexStatus.registeredActions.length} hooks)`);
+  } else if (codexStatus.adapterInstalled) {
+    console.log(`  ✗ Codex App hooks incomplete (missing: ${codexStatus.missingActions.join(", ")})`);
+  } else {
+    console.log("  ✗ Codex App adapter not found. Run: openwolf init");
   }
 
   // Token ledger stats

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -3,7 +3,7 @@
  *
  * For each project:
  * 1. Creates a timestamped backup in .wolf/backups/
- * 2. Updates hooks, templates, protocol files, and claude rules
+ * 2. Updates hooks, templates, protocol files, Claude rules, and Codex App hooks
  * 3. Preserves all user data (cerebrum, memory, anatomy, buglog, ledger)
  * 4. Reports results per project
  */
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url";
 import { getRegisteredProjects, registerProject, type RegisteredProject } from "./registry.js";
 import { readJSON, writeJSON, readText, writeText } from "../utils/fs-safe.js";
 import { ensureDir } from "../utils/paths.js";
+import { installCodexAppHooks } from "../codex/codex-hooks.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -192,14 +193,23 @@ async function updateProject(
     }
     console.log(`    ✓ Claude settings updated`);
 
-    // 5. Update .claude/rules/openwolf.md
+    // 5. Update Codex App global hooks
+    try {
+      const codexHooks = installCodexAppHooks();
+      console.log(`    ✓ Codex App hooks updated (${codexHooks.entryCount} hooks)`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`    ⚠ Codex App hooks not updated: ${msg}`);
+    }
+
+    // 6. Update .claude/rules/openwolf.md
     const rulesDir = path.join(claudeDir, "rules");
     ensureDir(rulesDir);
     const rulesContent = readTemplateContent("claude-rules-openwolf.md", templatesDir);
     writeText(path.join(rulesDir, "openwolf.md"), rulesContent);
     console.log(`    ✓ Claude rules updated`);
 
-    // 6. Update CLAUDE.md snippet if it references OpenWolf
+    // 7. Update CLAUDE.md snippet if it references OpenWolf
     const claudeMdPath = path.join(root, "CLAUDE.md");
     const snippetContent = readTemplateContent("claude-md-snippet.md", templatesDir);
     if (fs.existsSync(claudeMdPath)) {
@@ -210,7 +220,7 @@ async function updateProject(
       }
     }
 
-    // 7. Clean up stale .tmp files
+    // 8. Clean up stale .tmp files
     try {
       const files = fs.readdirSync(wolfDir);
       let cleaned = 0;
@@ -222,7 +232,7 @@ async function updateProject(
       if (cleaned > 0) console.log(`    ✓ Cleaned ${cleaned} stale .tmp file(s)`);
     } catch {}
 
-    // 8. Update registry entry
+    // 9. Update registry entry
     registerProject(root, name, version);
 
     return {

--- a/src/codex/codex-hooks.ts
+++ b/src/codex/codex-hooks.ts
@@ -1,0 +1,181 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readJSON, writeJSON } from "../utils/fs-safe.js";
+import { ensureDir } from "../utils/paths.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const ADAPTER_FILENAME = "openwolf_codex_hook.mjs";
+const OPENWOLF_CODEX_ACTIONS = ["session-start", "pre-read", "pre-write", "post-read", "post-write", "stop"] as const;
+
+type HookAction = typeof OPENWOLF_CODEX_ACTIONS[number];
+
+interface HookCommand {
+  type: string;
+  command?: string;
+  commandWindows?: string;
+  timeout?: number;
+  statusMessage?: string;
+}
+
+interface HookMatcher {
+  matcher?: string;
+  hooks?: HookCommand[];
+}
+
+interface HooksFile {
+  hooks?: Record<string, HookMatcher[]>;
+}
+
+export interface CodexHookInstallResult {
+  hooksPath: string;
+  adapterPath: string;
+  entryCount: number;
+}
+
+export interface CodexHookStatus {
+  hooksPath: string;
+  adapterPath: string;
+  adapterInstalled: boolean;
+  registeredActions: string[];
+  missingActions: string[];
+}
+
+export function installCodexAppHooks(): CodexHookInstallResult {
+  const codexHome = getCodexHome();
+  const hooksDir = path.join(codexHome, "hooks");
+  ensureDir(hooksDir);
+
+  const adapterPath = path.join(hooksDir, ADAPTER_FILENAME);
+  fs.writeFileSync(adapterPath, readAdapterSource(), "utf-8");
+
+  const hooksPath = path.join(codexHome, "hooks.json");
+  const existing = readJSON<HooksFile>(hooksPath, { hooks: {} });
+  const merged = replaceOpenWolfCodexHooks(existing, adapterPath);
+  writeJSON(hooksPath, merged);
+
+  return {
+    hooksPath,
+    adapterPath,
+    entryCount: OPENWOLF_CODEX_ACTIONS.length,
+  };
+}
+
+export function getCodexAppHookStatus(): CodexHookStatus {
+  const codexHome = getCodexHome();
+  const hooksPath = path.join(codexHome, "hooks.json");
+  const adapterPath = path.join(codexHome, "hooks", ADAPTER_FILENAME);
+  const hooksFile = readJSON<HooksFile>(hooksPath, { hooks: {} });
+  const registeredActions = findRegisteredActions(hooksFile);
+  const missingActions = OPENWOLF_CODEX_ACTIONS.filter((action) => !registeredActions.includes(action));
+
+  return {
+    hooksPath,
+    adapterPath,
+    adapterInstalled: fs.existsSync(adapterPath),
+    registeredActions,
+    missingActions,
+  };
+}
+
+function getCodexHome(): string {
+  const explicit = process.env.CODEX_HOME;
+  if (explicit && explicit.trim()) return explicit.trim();
+  return path.join(os.homedir(), ".codex");
+}
+
+function replaceOpenWolfCodexHooks(existing: HooksFile, adapterPath: string): HooksFile {
+  const merged: HooksFile = { ...existing, hooks: { ...(existing.hooks ?? {}) } };
+  const hooks = merged.hooks!;
+
+  for (const [event, entries] of Object.entries(hooks)) {
+    hooks[event] = entries.filter((entry) => !isOpenWolfCodexEntry(entry));
+  }
+
+  const command = adapterCommand(adapterPath);
+  hooks.SessionStart = [
+    ...(hooks.SessionStart ?? []),
+    codexEntry(command("session-start"), 5, "OpenWolf: starting session"),
+  ];
+  hooks.PreToolUse = [
+    ...(hooks.PreToolUse ?? []),
+    codexEntry(command("pre-read"), 5),
+    codexEntry(command("pre-write"), 5),
+  ];
+  hooks.PostToolUse = [
+    ...(hooks.PostToolUse ?? []),
+    codexEntry(command("post-read"), 5),
+    codexEntry(command("post-write"), 10),
+  ];
+  hooks.Stop = [
+    ...(hooks.Stop ?? []),
+    codexEntry(command("stop"), 10),
+  ];
+
+  for (const [event, entries] of Object.entries(hooks)) {
+    if (entries.length === 0) delete hooks[event];
+  }
+
+  return merged;
+}
+
+function findRegisteredActions(hooksFile: HooksFile): string[] {
+  const actions = new Set<string>();
+  for (const entries of Object.values(hooksFile.hooks ?? {})) {
+    for (const entry of entries) {
+      for (const hook of entry.hooks ?? []) {
+        const command = `${hook.command ?? ""} ${hook.commandWindows ?? ""}`;
+        if (!command.includes(ADAPTER_FILENAME)) continue;
+        for (const action of OPENWOLF_CODEX_ACTIONS) {
+          if (command.includes(` ${action}`) || command.endsWith(action)) actions.add(action);
+        }
+      }
+    }
+  }
+  return [...actions].sort();
+}
+
+function isOpenWolfCodexEntry(entry: HookMatcher): boolean {
+  return Boolean(entry.hooks?.some((hook) => {
+    const command = `${hook.command ?? ""} ${hook.commandWindows ?? ""}`;
+    return command.includes(ADAPTER_FILENAME);
+  }));
+}
+
+function adapterCommand(adapterPath: string): (action: HookAction) => string {
+  const escaped = adapterPath.replace(/"/g, '\\"');
+  return (action) => `node "${escaped}" ${action}`;
+}
+
+function codexEntry(command: string, timeout: number, statusMessage?: string, matcher?: string): HookMatcher {
+  const hook: HookCommand = {
+    type: "command",
+    command,
+    commandWindows: command,
+    timeout,
+  };
+  if (statusMessage) hook.statusMessage = statusMessage;
+
+  return {
+    ...(matcher ? { matcher } : {}),
+    hooks: [hook],
+  };
+}
+
+function readAdapterSource(): string {
+  const candidates = [
+    path.join(__dirname, "openwolf-codex-hook.js"),
+    path.resolve(__dirname, "..", "codex", "openwolf-codex-hook.js"),
+  ];
+
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue;
+    const content = fs.readFileSync(candidate, "utf-8");
+    return content.replace(/^#!.*\n/, "#!/usr/bin/env node\n");
+  }
+
+  throw new Error("OpenWolf Codex adapter source not found. Run `pnpm build` and retry.");
+}

--- a/src/codex/openwolf-codex-hook.ts
+++ b/src/codex/openwolf-codex-hook.ts
@@ -1,0 +1,531 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+type JsonRecord = Record<string, unknown>;
+
+interface NormalizedHookInput {
+  hook_event_name?: string;
+  session_id?: string;
+  cwd?: string;
+  tool_name?: string;
+  tool_input?: JsonRecord;
+  tool_output?: { content?: string };
+  tool_response?: unknown;
+}
+
+interface FileChange {
+  filePath: string;
+  content?: string;
+  oldString?: string;
+  newString?: string;
+  toolName?: string;
+}
+
+const SCRIPT_BY_ACTION = new Map<string, string>([
+  ["session-start", "session-start.js"],
+  ["pre-read", "pre-read.js"],
+  ["pre-write", "pre-write.js"],
+  ["post-read", "post-read.js"],
+  ["post-write", "post-write.js"],
+  ["stop", "stop.js"],
+]);
+
+const SHELL_TOOL_NAMES = new Set([
+  "bash",
+  "shell",
+  "shell_command",
+  "functions.shell_command",
+]);
+
+const APPLY_PATCH_TOOL_NAMES = new Set([
+  "apply_patch",
+  "functions.apply_patch",
+]);
+
+const MULTI_TOOL_NAMES = new Set([
+  "multi_tool_use.parallel",
+  "functions.multi_tool_use.parallel",
+]);
+
+const READ_TOOL_NAMES = new Set([
+  "read",
+  "view",
+  "glob",
+  "grep",
+  "ls",
+]);
+
+const WRITE_TOOL_NAMES = new Set([
+  "write",
+  "edit",
+  "multiedit",
+  "notebookedit",
+  "create",
+]);
+
+const action = process.argv[2] || "";
+const scriptName = SCRIPT_BY_ACTION.get(action);
+if (!scriptName) {
+  process.exit(0);
+}
+
+const rawPayload = await readStdin();
+const hookInput = parseJson(rawPayload);
+const startDirectory = findStartDirectory(hookInput);
+const projectRoot = findWolfProjectRoot(startDirectory);
+
+if (!projectRoot) {
+  process.exit(0);
+}
+
+const scriptPath = path.join(projectRoot, ".wolf", "hooks", scriptName);
+if (!fs.existsSync(scriptPath)) {
+  process.exit(0);
+}
+
+const normalizedInputs = normalizeForAction(action, hookInput, projectRoot);
+if (normalizedInputs.length === 0) {
+  process.exit(0);
+}
+
+let exitCode = 0;
+for (const input of normalizedInputs) {
+  const code = await runOpenWolfHook(scriptPath, projectRoot, input);
+  if (code !== 0) exitCode = code;
+}
+
+process.exit(exitCode);
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    process.stdin.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    setTimeout(() => resolve(chunks.length ? Buffer.concat(chunks).toString("utf8") : "{}"), 2000);
+  });
+}
+
+function parseJson(raw: string): JsonRecord {
+  try {
+    const parsed = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeForAction(actionName: string, input: JsonRecord, projectRoot: string): NormalizedHookInput[] {
+  if (actionName === "session-start" || actionName === "stop") {
+    return [withBaseFields(input, projectRoot)];
+  }
+
+  if (actionName === "pre-read" || actionName === "post-read") {
+    return buildReadInputs(input, projectRoot);
+  }
+
+  if (actionName === "pre-write" || actionName === "post-write") {
+    return buildWriteInputs(input, projectRoot, actionName === "post-write");
+  }
+
+  return [];
+}
+
+function buildReadInputs(input: JsonRecord, projectRoot: string): NormalizedHookInput[] {
+  const toolName = getToolName(input);
+  const normalizedToolName = normalizeToolName(toolName);
+  const toolInput = getToolInput(input);
+
+  if (MULTI_TOOL_NAMES.has(normalizedToolName)) {
+    return getParallelToolUses(toolInput).flatMap((toolUse) => buildReadInputs(toolUse, projectRoot));
+  }
+
+  const paths = new Set<string>();
+  if (READ_TOOL_NAMES.has(normalizedToolName)) {
+    for (const filePath of getPathValues(toolInput)) paths.add(filePath);
+  }
+
+  if (SHELL_TOOL_NAMES.has(normalizedToolName)) {
+    const command = getCommand(toolInput);
+    if (isShellReadCommand(command)) {
+      for (const filePath of extractShellReadPaths(command, projectRoot)) paths.add(filePath);
+    }
+  }
+
+  const output = outputToString(getToolOutput(input));
+  return [...paths]
+    .map((filePath) => resolveExistingFile(filePath, projectRoot))
+    .filter((filePath): filePath is string => Boolean(filePath))
+    .map((filePath) => ({
+      ...withBaseFields(input, projectRoot),
+      tool_name: "Read",
+      tool_input: { file_path: filePath },
+      tool_output: { content: output },
+    }));
+}
+
+function buildWriteInputs(input: JsonRecord, projectRoot: string, skipDeletedFiles: boolean): NormalizedHookInput[] {
+  const toolName = getToolName(input);
+  const normalizedToolName = normalizeToolName(toolName);
+  const toolInput = getToolInput(input);
+
+  if (MULTI_TOOL_NAMES.has(normalizedToolName)) {
+    return getParallelToolUses(toolInput).flatMap((toolUse) => buildWriteInputs(toolUse, projectRoot, skipDeletedFiles));
+  }
+
+  let changes: FileChange[] = [];
+  if (APPLY_PATCH_TOOL_NAMES.has(normalizedToolName)) {
+    changes = parseApplyPatchChanges(toolInput, projectRoot, skipDeletedFiles);
+  } else if (WRITE_TOOL_NAMES.has(normalizedToolName)) {
+    changes = getPathValues(toolInput).map((filePath) => ({
+      filePath,
+      content: stringValue(toolInput.content),
+      oldString: stringValue(toolInput.old_string),
+      newString: stringValue(toolInput.new_string),
+      toolName: denormalizeWriteToolName(normalizedToolName),
+    }));
+  } else if (SHELL_TOOL_NAMES.has(normalizedToolName)) {
+    const command = getCommand(toolInput);
+    if (isShellWriteCommand(command)) {
+      changes = extractShellWritePaths(command, projectRoot).map((filePath) => ({
+        filePath,
+        content: command,
+        newString: command,
+        toolName: "Edit",
+      }));
+    }
+  }
+
+  return changes
+    .map((change) => ({
+      change,
+      filePath: resolveWritePath(change.filePath, projectRoot),
+    }))
+    .filter(({ filePath }) => Boolean(filePath))
+    .map(({ change, filePath }) => ({
+      ...withBaseFields(input, projectRoot),
+      tool_name: change.toolName || "Edit",
+      tool_input: {
+        file_path: filePath,
+        content: change.content || "",
+        old_string: change.oldString || "",
+        new_string: change.newString || "",
+      },
+    }));
+}
+
+function parseApplyPatchChanges(toolInput: JsonRecord, projectRoot: string, skipDeletedFiles: boolean): FileChange[] {
+  const patch = extractPatchText(toolInput);
+  if (!patch) return [];
+
+  const changes: FileChange[] = [];
+  let current: (FileChange & { deleted?: boolean; addedLines: string[]; removedLines: string[] }) | null = null;
+
+  const finishCurrent = () => {
+    if (!current) return;
+    if (current.deleted && skipDeletedFiles) {
+      current = null;
+      return;
+    }
+    const oldString = current.removedLines.join("\n");
+    const newString = current.addedLines.join("\n");
+    changes.push({
+      filePath: current.filePath,
+      content: newString,
+      oldString,
+      newString,
+      toolName: current.addedLines.length > 0 && current.removedLines.length === 0 ? "Write" : "Edit",
+    });
+    current = null;
+  };
+
+  for (const line of patch.split(/\r?\n/)) {
+    const fileMatch = line.match(/^\*\*\* (Add|Update|Delete) File: (.+)$/);
+    if (fileMatch) {
+      finishCurrent();
+      current = {
+        filePath: resolveWritePath(fileMatch[2].trim(), projectRoot) || fileMatch[2].trim(),
+        deleted: fileMatch[1] === "Delete",
+        addedLines: [],
+        removedLines: [],
+      };
+      continue;
+    }
+
+    const moveMatch = line.match(/^\*\*\* Move to: (.+)$/);
+    if (moveMatch && current) {
+      current.filePath = resolveWritePath(moveMatch[1].trim(), projectRoot) || moveMatch[1].trim();
+      continue;
+    }
+
+    if (!current) continue;
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      current.addedLines.push(line.slice(1));
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      current.removedLines.push(line.slice(1));
+    }
+  }
+
+  finishCurrent();
+  return changes;
+}
+
+function extractPatchText(toolInput: JsonRecord): string {
+  if (typeof toolInput.patch === "string") return toolInput.patch;
+  if (typeof toolInput.input === "string") return toolInput.input;
+  if (typeof toolInput.content === "string") return toolInput.content;
+  if (typeof toolInput.command === "string" && toolInput.command.includes("*** Begin Patch")) return toolInput.command;
+  return "";
+}
+
+function withBaseFields(input: JsonRecord, projectRoot: string): NormalizedHookInput {
+  const cwd = findStartDirectory(input) || projectRoot;
+  return {
+    hook_event_name: typeof input.hook_event_name === "string" ? input.hook_event_name : undefined,
+    session_id: typeof input.session_id === "string" ? input.session_id : typeof input.sessionId === "string" ? input.sessionId : undefined,
+    cwd,
+  };
+}
+
+function getToolName(input: JsonRecord): string {
+  if (typeof input.tool_name === "string") return input.tool_name;
+  if (typeof input.toolName === "string") return input.toolName;
+  if (typeof input.recipient_name === "string") return input.recipient_name;
+  if (typeof input.name === "string") return input.name;
+  return "";
+}
+
+function normalizeToolName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function denormalizeWriteToolName(name: string): string {
+  if (name === "write" || name === "create") return "Write";
+  if (name === "multiedit") return "MultiEdit";
+  return "Edit";
+}
+
+function getToolInput(input: JsonRecord): JsonRecord {
+  const raw = input.tool_input ?? input.toolArgs ?? input.parameters ?? input.args ?? {};
+  if (isRecord(raw)) return raw;
+  if (typeof raw === "string") return { input: raw };
+  return {};
+}
+
+function getParallelToolUses(toolInput: JsonRecord): JsonRecord[] {
+  if (!Array.isArray(toolInput.tool_uses)) return [];
+  return toolInput.tool_uses
+    .filter(isRecord)
+    .map((toolUse) => ({
+      tool_name: typeof toolUse.recipient_name === "string" ? toolUse.recipient_name : getToolName(toolUse),
+      tool_input: isRecord(toolUse.parameters) ? toolUse.parameters : {},
+    }));
+}
+
+function getToolOutput(input: JsonRecord): unknown {
+  return input.tool_output ?? input.tool_response ?? input.tool_result ?? input.toolResult ?? input.output ?? input.result;
+}
+
+function outputToString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  if (Array.isArray(value)) return value.map(outputToString).filter(Boolean).join("\n");
+  if (isRecord(value)) {
+    for (const key of ["content", "stdout", "stderr", "output", "text_result_for_llm", "textResultForLlm"]) {
+      const nested = value[key];
+      if (typeof nested === "string") return nested;
+    }
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "";
+    }
+  }
+  return String(value);
+}
+
+function getPathValues(toolInput: JsonRecord): string[] {
+  const keys = ["file_path", "path", "file", "filename"];
+  const values: string[] = [];
+  for (const key of keys) {
+    const value = toolInput[key];
+    if (typeof value === "string" && value.trim()) values.push(value);
+  }
+  if (Array.isArray(toolInput.files)) {
+    for (const value of toolInput.files) {
+      if (typeof value === "string" && value.trim()) values.push(value);
+    }
+  }
+  return values;
+}
+
+function getCommand(toolInput: JsonRecord): string {
+  return typeof toolInput.command === "string" ? toolInput.command : "";
+}
+
+function isShellReadCommand(command: string): boolean {
+  return /\b(Get-Content|gc|cat|type|Select-String|rg|grep|sed|nl|Get-ChildItem|gci|ls|dir)\b/i.test(command);
+}
+
+function isShellWriteCommand(command: string): boolean {
+  return /\b(Set-Content|Add-Content|Out-File|New-Item|Copy-Item|Move-Item)\b/i.test(command) || /(^|[^>])>{1,2}\s*["']?[^"'\s]+/m.test(command);
+}
+
+function extractShellReadPaths(command: string, projectRoot: string): string[] {
+  const tokens = tokenizeCommand(command);
+  const paths: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const lower = token.toLowerCase();
+    if (["-path", "-literalpath"].includes(lower) && tokens[i + 1]) {
+      paths.push(tokens[i + 1]);
+      i++;
+      continue;
+    }
+    if (looksLikePath(token)) {
+      paths.push(token);
+    }
+  }
+  return unique(paths.filter((candidate) => Boolean(resolveExistingFile(candidate, projectRoot))));
+}
+
+function extractShellWritePaths(command: string, projectRoot: string): string[] {
+  const paths: string[] = [];
+  const redirection = command.matchAll(/(?:^|[^>])>{1,2}\s*("[^"]+"|'[^']+'|\S+)/g);
+  for (const match of redirection) paths.push(stripQuotes(match[1]));
+
+  const tokens = tokenizeCommand(command);
+  for (let i = 0; i < tokens.length; i++) {
+    const lower = tokens[i].toLowerCase();
+    if (["-path", "-literalpath", "-filepath", "-destination"].includes(lower) && tokens[i + 1]) {
+      paths.push(tokens[i + 1]);
+      i++;
+    }
+  }
+
+  return unique(paths.map((candidate) => resolveWritePath(candidate, projectRoot)).filter((candidate): candidate is string => Boolean(candidate)));
+}
+
+function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  const regex = /"([^"]+)"|'([^']+)'|`([^`]+)`|([^\s]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(command)) !== null) {
+    tokens.push(match[1] ?? match[2] ?? match[3] ?? match[4]);
+  }
+  return tokens;
+}
+
+function looksLikePath(token: string): boolean {
+  if (!token || token.startsWith("-")) return false;
+  if (/^[|;&]$/.test(token)) return false;
+  if (/^(https?:)?\/\//i.test(token)) return false;
+  if (/[*?]/.test(token)) return false;
+  if (/^[A-Za-z_][\w-]*$/.test(token)) return false;
+  return /[\\/]|\.([A-Za-z0-9]{1,8})$/.test(token);
+}
+
+function resolveExistingFile(filePath: string, projectRoot: string): string | null {
+  const resolved = resolveWritePath(filePath, projectRoot);
+  if (!resolved) return null;
+  try {
+    return fs.statSync(resolved).isFile() ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveWritePath(filePath: string, projectRoot: string): string | null {
+  const clean = stripQuotes(filePath).replace(/[),;]+$/g, "");
+  if (!clean || clean.startsWith("-") || /^(https?:)?\/\//i.test(clean)) return null;
+  try {
+    const resolved = path.resolve(projectRoot, clean);
+    return isInsideProject(resolved, projectRoot) ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function isInsideProject(filePath: string, projectRoot: string): boolean {
+  const relative = path.relative(projectRoot, filePath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function stripQuotes(value: string): string {
+  return value.trim().replace(/^["'`]|["'`]$/g, "");
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function findStartDirectory(input: JsonRecord): string {
+  const toolInput = getToolInput(input);
+  const candidates = [
+    typeof input.cwd === "string" ? input.cwd : "",
+    typeof toolInput.workdir === "string" ? toolInput.workdir : "",
+    process.env.OPENWOLF_PROJECT_DIR || "",
+    process.env.CODEX_PROJECT_DIR || "",
+    process.env.CLAUDE_PROJECT_DIR || "",
+    process.cwd(),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const resolved = path.resolve(candidate);
+      if (fs.existsSync(resolved)) {
+        const stat = fs.statSync(resolved);
+        return stat.isDirectory() ? resolved : path.dirname(resolved);
+      }
+    } catch {}
+  }
+
+  return process.cwd();
+}
+
+function findWolfProjectRoot(startDirectory: string): string | null {
+  let current = path.resolve(startDirectory);
+  while (true) {
+    if (fs.existsSync(path.join(current, ".wolf", "hooks"))) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function runOpenWolfHook(scriptPath: string, projectRoot: string, input: NormalizedHookInput): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        OPENWOLF_PROJECT_DIR: projectRoot,
+        CODEX_PROJECT_DIR: projectRoot,
+        CLAUDE_PROJECT_DIR: projectRoot,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    child.stdin.end(JSON.stringify(input));
+    child.stdout.pipe(process.stdout);
+    child.stderr.pipe(process.stderr);
+    child.on("error", () => resolve(0));
+    child.on("close", (code) => resolve(code ?? 0));
+  });
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/hooks/post-read.ts
+++ b/src/hooks/post-read.ts
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
   const normalizedFile = normalizePath(filePath);
 
   // Skip tracking for .wolf/ internal files — consistent with pre-read
-  const projectDir = normalizePath(process.env.CLAUDE_PROJECT_DIR || process.cwd());
+  const projectDir = normalizePath(process.env.OPENWOLF_PROJECT_DIR || process.env.CODEX_PROJECT_DIR || process.env.CLAUDE_PROJECT_DIR || process.cwd());
   const relToProject = normalizedFile.startsWith(projectDir)
     ? normalizedFile.slice(projectDir.length).replace(/^\//, "")
     : "";

--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
   const wolfDir = getWolfDir();
   const hooksDir = path.join(wolfDir, "hooks");
   const sessionFile = path.join(hooksDir, "_session.json");
-  const projectRoot = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const projectRoot = process.env.OPENWOLF_PROJECT_DIR || process.env.CODEX_PROJECT_DIR || process.env.CLAUDE_PROJECT_DIR || process.cwd();
 
   const raw = await readStdin();
   let input: { tool_name?: string; tool_input?: { file_path?: string; path?: string; content?: string; old_string?: string; new_string?: string } };

--- a/src/hooks/pre-read.ts
+++ b/src/hooks/pre-read.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
 
   // Skip tracking for .wolf/ internal files — they're infrastructure, not project files.
   // Counting them inflates anatomy miss rates since .wolf/ is excluded from anatomy scanning.
-  const projectDir = normalizePath(process.env.CLAUDE_PROJECT_DIR || process.cwd());
+  const projectDir = normalizePath(process.env.OPENWOLF_PROJECT_DIR || process.env.CODEX_PROJECT_DIR || process.env.CLAUDE_PROJECT_DIR || process.cwd());
   const relToProject = normalizedFile.startsWith(projectDir)
     ? normalizedFile.slice(projectDir.length).replace(/^\//, "")
     : "";

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -3,8 +3,8 @@ import * as path from "node:path";
 import * as crypto from "node:crypto";
 
 export function getWolfDir(): string {
-  // Prefer CLAUDE_PROJECT_DIR so hooks work even if CWD changes during a session
-  const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  // Prefer explicit hook project vars so hooks work even if CWD changes during a session.
+  const projectDir = process.env.OPENWOLF_PROJECT_DIR || process.env.CODEX_PROJECT_DIR || process.env.CLAUDE_PROJECT_DIR || process.cwd();
   return path.join(projectDir, ".wolf");
 }
 


### PR DESCRIPTION
Adds Codex App support for OpenWolf by installing a global Codex hook adapter during init/update. The adapter maps Codex App tool payloads into the existing OpenWolf hook lifecycle, keeps Claude Code hooks unchanged, and updates status/docs to report Codex App registration.\n\nVerification:\n- pnpm build\n- tsc -p tsconfig.json --noEmit\n- tsc -p tsconfig.hooks.json --noEmit\n- openwolf init/status in Agent_CRM\n- manual Codex-style payload tests for shell_command/apply_patch/multi_tool_use.parallel