### PR TITLE
fix(hooks): don't track files outside the project root in anatomy

### DIFF
--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -56,6 +56,11 @@ async function main(): Promise<void> {
   const relPath = normalizePath(path.relative(projectRoot, absolutePath));
   if (relPath.startsWith(".wolf/")) { process.exit(0); return; }
 
+  // Never track files outside the project root (e.g. the Claude Code scratchpad under
+  // /private/tmp). path.relative() yields ../.. section keys that pollute anatomy.md and are
+  // wiped again by every full `openwolf scan`, so the index churns instead of converging.
+  if (relPath.startsWith("..")) { process.exit(0); return; }
+
   // Never track .env files in anatomy — they contain secrets
   const baseName = path.basename(absolutePath);
   if (baseName === ".env" || baseName.startsWith(".env.")) { process.exit(0); return; }


### PR DESCRIPTION
## Problem

The `post-write` hook adds the file just written to `anatomy.md`, keyed by its path **relative to the project root**. There are guards for `.wolf/` internal files and for `.env`, but none for files *outside* the project root.

When Claude Code writes to its scratchpad (under `/private/tmp/claude-.../scratchpad/`), `path.relative(projectRoot, absolutePath)` returns something like:

```
../../../private/tmp/claude-501/-Users-.../scratchpad/foo.md
```

`post-write` then creates a section header `## ../../../private/tmp/.../scratchpad/` in `anatomy.md`. A subsequent full `openwolf scan` only walks the project root, so it drops that section again — the index churns between the two writers and the tracked-file count in the header drifts.

I hit this while debugging an anatomy coverage issue: after a few in-session scratchpad writes, `anatomy.md` had a `/private/tmp/.../scratchpad/` section at the very top that no `scan` had put there.

## Fix

Skip any file whose project-relative path starts with `..` (i.e. resolves outside the project root), right after the existing `.wolf/` guard:

```ts
if (relPath.startsWith("..")) { process.exit(0); return; }
```

`startsWith("..")` covers both `../` (POSIX) and `..\` (Windows), since `normalizePath` can't turn an out-of-tree path into an in-tree one. It mirrors the style of the adjacent `.wolf/` / `.env` guards. Source-only change; `dist/` isn't tracked in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
