### PR TITLE
fix(post-write): stop auto-logging non-code edits as bugs; add opt-out flag

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -348,6 +348,7 @@ function generateTemplate(destPath: string, file: string): void {
         daemon: { port: 18790, log_level: "info" },
         dashboard: { enabled: true, port: 18791 },
         designqc: { enabled: true, viewports: [{ name: "desktop", width: 1440, height: 900 }, { name: "mobile", width: 375, height: 812 }], max_screenshots: 6, chrome_path: null },
+        buglog: { auto_detect: true },
       },
     }, null, 2),
     "token-ledger.json": JSON.stringify({ version: 1, created_at: "", lifetime: { total_tokens_estimated: 0, total_reads: 0, total_writes: 0, total_sessions: 0, anatomy_hits: 0, anatomy_misses: 0, repeated_reads_blocked: 0, estimated_savings_vs_bare_cli: 0 }, sessions: [], daemon_usage: [], waste_flags: [], optimization_report: { last_generated: null, patterns: [] } }, null, 2),

--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -6,6 +6,17 @@ import {
   extractDescription, estimateTokens, appendMarkdown, timeShort, readStdin, normalizePath
 } from "./shared.js";
 
+// File types where a value/string change is normal content editing, not a bug
+// fix — auto bug detection never runs on these (see autoDetectBugFix). Without
+// this, a version bump in a README or a key change in a JSON/YAML config is
+// logged as a "wrong-value" bug, since the detector matches quoted spans
+// (including markdown backticks) regardless of file type.
+const NON_CODE_EXTS = new Set([
+  ".md", ".mdx", ".markdown", ".txt", ".rst", ".adoc",
+  ".json", ".jsonc", ".yaml", ".yml", ".toml", ".ini", ".env",
+  ".lock", ".csv", ".tsv",
+]);
+
 interface SessionData {
   files_written: Array<{ file: string; action: string; tokens: number; at: string }>;
   edit_counts: Record<string, number>;
@@ -283,12 +294,31 @@ function extractCalls(code: string): string[] {
 
 // ─── Auto Bug Detection ──────────────────────────────────────────
 
+function bugAutoDetectEnabled(wolfDir: string): boolean {
+  try {
+    const cfg = readJSON<{ openwolf?: { buglog?: { auto_detect?: boolean } } }>(
+      path.join(wolfDir, "config.json"),
+      {}
+    );
+    // Default on; only an explicit `false` disables auto bug detection.
+    return cfg.openwolf?.buglog?.auto_detect !== false;
+  } catch {
+    return true;
+  }
+}
+
 function autoDetectBugFix(wolfDir: string, absolutePath: string, projectRoot: string, oldStr: string, newStr: string): void {
+  const basename = path.basename(absolutePath);
+  const ext = path.extname(basename).toLowerCase();
+
+  // Bug-fix detection is a code concept — never fire on prose/docs/data files.
+  if (NON_CODE_EXTS.has(ext)) return;
+  // Respect an explicit opt-out in .wolf/config.json (default: enabled).
+  if (!bugAutoDetectEnabled(wolfDir)) return;
+
   const bugLogPath = path.join(wolfDir, "buglog.json");
   const bugLog = readJSON<BugLog>(bugLogPath, { version: 1, bugs: [] });
   const relFile = normalizePath(path.relative(projectRoot, absolutePath));
-  const basename = path.basename(absolutePath);
-  const ext = path.extname(basename).toLowerCase();
 
   // Detect what kind of fix this is
   const detection = detectFixPattern(oldStr, newStr, ext);


### PR DESCRIPTION
## Problem
`autoDetectBugFix` in `src/hooks/post-write.ts` runs on every `Edit` and its "wrong-value" detector matches any quoted span — `/['"\`]([^'"\`]{2,})['"\`]/` — **including markdown backticks**, with no file-type gate. So ordinary content edits get logged to `.wolf/buglog.json` as `"Incorrect value in code"` bugs:

- Bumping a version string in a README (e.g. `` `Xcode_26.4.1.app` `` → `` `Xcode_26.5.app` ``) → logged as a bug.
- Changing a key/value in a JSON/YAML config → logged as a bug.

It then re-serializes the file (inlining arrays → multiline, dropping the trailing newline). Because `buglog.json` is tracked, every such edit shows up as a spurious diff that has to be reverted by hand, and there's no way to turn the heuristic off.

## Fix
Two small, backward-compatible changes:

1. **Skip prose/docs/data files.** A new `NON_CODE_EXTS` set (`.md`, `.mdx`, `.markdown`, `.txt`, `.rst`, `.adoc`, `.json`, `.jsonc`, `.yaml`, `.yml`, `.toml`, `.ini`, `.env`, `.lock`, `.csv`, `.tsv`) short-circuits `autoDetectBugFix` — a value change there is content editing, not a bug fix.
2. **Add an opt-out.** `autoDetectBugFix` now honors `openwolf.buglog.auto_detect` in `.wolf/config.json` (**default `true`**, so existing behavior is unchanged). Added to the `init.ts` config template.

Real code fixes (`.ts`/`.js`/etc.) with the flag on are still detected and logged.

## Verification
Built the hooks and ran `dist/hooks/post-write.js` against a sandbox `.wolf/`:

| Case | Edit | Result |
|------|------|--------|
| 1 | `.md`, backtick version-string change | **0** entries logged ✅ (was 1 before) |
| 2 | `.ts`, string-literal change, flag on | **1** entry logged ✅ (detection preserved) |
| 3 | `.ts`, string-literal change, flag **off** | no new entry ✅ (opt-out honored) |

`tsc -p tsconfig.hooks.json` and `tsc -p tsconfig.json` both pass (no test suite in the repo to update).

## Notes
- Filed after hitting this downstream, where we added a local pre-commit guard to strip `auto-detected` entries as a stopgap. This is the durable fix.

*(Authored with Claude Code.)*