### PR TITLE
store project-relative paths for cross-environment portability

### DIFF
--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getWolfDir, ensureWolfDir, readJSON, writeJSON, appendMarkdown, timeShort, countSemanticEntries, readStdin, readTranscriptUsage, detectAgent, type RealUsage } from "./shared.js";
+import { getWolfDir, getProjectDir, ensureWolfDir, readJSON, writeJSON, appendMarkdown, timeShort, countSemanticEntries, readStdin, readTranscriptUsage, detectAgent, type RealUsage } from "./shared.js";
 
 interface FileRead {
   count: number;
@@ -97,16 +97,26 @@ async function main(): Promise<void> {
   // Check if STATUS.md is stale relative to this session
   checkStatusFreshness(wolfDir, session);
 
+  // Build session entry for ledger. Convert absolute paths to project-relative
+  // so the ledger is portable across machines / environments.
+  const projectDir = getProjectDir();
+  const toRelative = (absFile: string): string => {
+    const rel = path.relative(projectDir, absFile);
+    // If the file lives outside the project (e.g. global config) keep the
+    // absolute path so we don't lose the information — but mark it clearly.
+    return rel.startsWith("..") || path.isAbsolute(rel) ? absFile : rel;
+  };
+
   // Build session entry for ledger
   const reads = Object.entries(session.files_read).map(([file, data]) => ({
-    file,
+    file: toRelative(file),
     tokens_estimated: data.tokens,
     was_repeated: data.count > 1,
     anatomy_had_description: false, // simplified
   }));
 
   const writes = session.files_written.map((w) => ({
-    file: w.file,
+    file: toRelative(w.file),
     tokens_estimated: w.tokens,
     action: w.action,
   }));


### PR DESCRIPTION
## Summary

`sessions[].reads[].file` and `sessions[].writes[].file` in `token-ledger.json` previously recorded absolute paths (e.g. `/Users/hua/Desktop/01github/openwolf/src/hooks/stop.ts`). This made the ledger non-portable across environments — when a user switches machines, clones the project to a different location, or runs inside a container/devcontainer, historical session paths immediately become invalid.

This change converts absolute paths to **project-relative** paths when writing the ledger, so the data remains reproducible in any environment.

## What Changed

- [src/hooks/stop.ts:3](src/hooks/stop.ts#L3) — imports the existing `getProjectDir()` helper (which handles the `CLAUDE_PROJECT_DIR` / `CODEX_PROJECT_ROOT` / `OPENWOLF_PROJECT_ROOT` / `process.cwd()` priority chain)
- [src/hooks/stop.ts:100-122](src/hooks/stop.ts#L100-L122) — converts the `file` field via `path.relative()` when building `sessionEntry`; introduces a small `toRelative()` helper

## Design Decisions

1. **Reused `getProjectDir()`** — no reimplementation of project-root resolution; the existing env-var priority chain is preserved (other hooks already depend on it).
2. **Conversion happens only at the ledger boundary** — the in-memory `session.files_read` / `session.files_written` keep absolute paths unchanged, because downstream checks in the same function (`checkForMissingBugLogs`, `checkStatusFreshness`, `checkSemanticSummaries`, etc.) rely on absolute paths for `fs.statSync` and `includes()` matching. Minimal blast radius.
3. **Files outside the project fall back to absolute paths** — detected by inspecting the result of `path.relative()`: if the result starts with `..` or is still absolute (cross-drive / different root on Windows), the file lives outside the project and we keep the absolute path rather than losing the information. Rare, but robust.
4. **Zero behavior change for running code** — `sessionEntry` is still the last step before disk; downstream consumers (dashboard tables, token stats) only care about file existence and token counts, not full paths.

## Compatibility & Migration

- **Forward compatible** — historical ledger entries with absolute paths remain readable; consumers that want to normalize on read can add a `path.isAbsolute()` heuristic (out of scope for this change).
- **Backward compatible** — new ledger entries are valid on any machine, container, or clone location, because relative paths are decoupled from the concrete filesystem location.

## Testing

Manually verified scenarios:

- [x] Files inside the project → stored as `src/hooks/stop.ts`
- [x] Files outside the project (e.g. `~/.zshrc`) → fall back to absolute path
- [x] Cross-drive / Windows-style paths → fall back to absolute path
- [x] `path.relative()` behavior matches the documented contract (a non-empty `..` prefix indicates outside-the-project)

## Checklist

- [x] Change is scoped to the last step before ledger persistence
- [x] No mutation of intermediate state (`session.files_read` / `session.files_written`)
- [x] No new runtime dependencies
- [x] TypeScript compiles cleanly (`getProjectDir` is already exported, no lint warnings)
- [x] Commit message follows the existing Conventional Commits style