### PR TITLE
fix(pre-read): skip repeated-read warning when file was modified since last read

### DIFF
--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -22,6 +22,7 @@ const NON_CODE_EXTS = new Set([
 ]);
 
 interface SessionData {
+  files_read: Record<string, { count: number; tokens: number; first_read: string; read_mtime?: number }>;
   files_written: Array<{ file: string; action: string; tokens: number; at: string }>;
   edit_counts: Record<string, number>;
   [key: string]: unknown;
@@ -157,10 +158,14 @@ async function main(): Promise<void> {
     appendMarkdown(memoryPath, `| ${timeShort()} | ${action} ${relFile} | ${outcome} | ~${writeTokens} |\n`);
   } catch {}
 
-  // 3. Record in session tracker + track edit counts
+  // 3. Record in session tracker + track edit counts.
+  //    Also clear the files_read entry for the written file — the file's
+  //    content just changed, so any cached read_mtime is now stale and a
+  //    subsequent re-read of this file is legitimate (not a repeated read).
   try {
-    const session = readJSON<SessionData>(sessionFile, { files_written: [], edit_counts: {} });
+    const session = readJSON<SessionData>(sessionFile, { files_read: {}, files_written: [], edit_counts: {} });
     if (!session.edit_counts) session.edit_counts = {};
+    if (!session.files_read) session.files_read = {};
 
     const normalizedFile = normalizePath(filePath);
     const action = toolName === "Write" ? "create" : "edit";
@@ -176,6 +181,10 @@ async function main(): Promise<void> {
 
     const editKey = normalizePath(path.relative(projectRoot, absolutePath));
     session.edit_counts[editKey] = (session.edit_counts[editKey] || 0) + 1;
+
+    // Invalidate the read cache for this file so the next read is not
+    // incorrectly flagged as a repeated read (the content just changed).
+    delete session.files_read[normalizedFile];
 
     writeJSON(sessionFile, session);
 

--- a/src/hooks/pre-read.ts
+++ b/src/hooks/pre-read.ts
@@ -8,7 +8,7 @@ import { lookupEntry } from "./anatomy-store.js";
 
 interface SessionData {
   session_id: string;
-  files_read: Record<string, { count: number; tokens: number; first_read: string }>;
+  files_read: Record<string, { count: number; tokens: number; first_read: string; read_mtime?: number }>;
   anatomy_hits: number;
   anatomy_misses: number;
   repeated_reads_warned: number;
@@ -54,14 +54,36 @@ async function main(): Promise<void> {
   // Check if already read this session
   if (session.files_read[normalizedFile]) {
     const prev = session.files_read[normalizedFile];
-    process.stderr.write(
-      `⚡ OpenWolf: ${path.basename(normalizedFile)} was already read this session (~${prev.tokens} tokens). Consider using your existing knowledge of this file.\n`
-    );
-    session.files_read[normalizedFile].count++;
-    session.repeated_reads_warned++;
-    writeJSON(sessionFile, session);
-    process.exit(0);
-    return;
+
+    // Compare current mtime against stored read_mtime — if the file was
+    // modified since the last read (by Claude or the user externally),
+    // the re-read is legitimate: clear the stale entry and fall through.
+    let fileChanged = false;
+    if (prev.read_mtime !== undefined) {
+      try {
+        const currentMtime = fs.statSync(normalizedFile).mtimeMs;
+        if (currentMtime > prev.read_mtime) {
+          fileChanged = true;
+        }
+      } catch {
+        // statSync failed (file deleted, permission error, etc.);
+        // treat as unchanged so we keep the existing warning behaviour.
+      }
+    }
+
+    if (!fileChanged) {
+      process.stderr.write(
+        `⚡ OpenWolf: ${path.basename(normalizedFile)} was already read this session (~${prev.tokens} tokens). Consider using your existing knowledge of this file.\n`
+      );
+      session.files_read[normalizedFile].count++;
+      session.repeated_reads_warned++;
+      writeJSON(sessionFile, session);
+      process.exit(0);
+      return;
+    }
+
+    // File was modified — reset entry so this read is treated as fresh.
+    delete session.files_read[normalizedFile];
   }
 
   // Anatomy lookup: O(1) against the durable store, legacy md scan fallback.
@@ -98,11 +120,21 @@ async function main(): Promise<void> {
     session.anatomy_misses++;
   }
 
-  // Record initial read entry (tokens will be updated in post-read)
+  // Record initial read entry (tokens will be updated in post-read).
+  // Capture mtime now so future re-reads can detect if the file changed.
+  let readMtime: number | undefined;
+  try {
+    readMtime = fs.statSync(normalizedFile).mtimeMs;
+  } catch {
+    // File may not exist yet (e.g. read of a path about to be created);
+    // leave read_mtime undefined so mtime comparison is skipped next time.
+  }
+
   session.files_read[normalizedFile] = {
     count: 1,
     tokens: 0,
     first_read: new Date().toISOString(),
+    read_mtime: readMtime,
   };
 
   writeJSON(sessionFile, session);


### PR DESCRIPTION
## Summary

Fixes #41 — `pre-read` hook blocks re-reads even after the file was modified during the session.

The `pre-read` hook currently warns on **every** re-read of a file seen this session, even when Claude just wrote to that file or the user edited it externally. This inflates `repeated_reads_warned` and `estimated_savings_vs_bare_cli` stats with false positives, and — more practically — suppresses the anatomy hint and re-read token estimate that Claude *needs* after a file changes.

---

## What changed

**`src/hooks/pre-read.ts`**
- Problem: `session.files_read[normalizedFile]` stored only `count`, `tokens`, and `first_read` — no mtime snapshot, so there was no way to detect a change between reads.
- Change 1: When recording the initial read entry, capture `read_mtime: fs.statSync(normalizedFile).mtimeMs` (wrapped in `try/catch`; if `statSync` fails, `read_mtime` is left `undefined` and the old behaviour is preserved).
- Change 2: On re-read, if `prev.read_mtime !== undefined`, compare current `statSync(normalizedFile).mtimeMs` against the stored value. If `currentMtime > prev.read_mtime`, the file changed — delete the stale entry and fall through to the normal first-read path (anatomy hint, no warning). If mtime is unchanged, the existing repeated-read warning fires as before.

**`src/hooks/post-write.ts`**
- Problem: After Claude writes to a file, the `files_read` session entry for that file still held the old `read_mtime`. The next `pre-read` of the same file would have to go through a `statSync` comparison to detect the change, which is fine — but the write hook already *knows* the file changed.
- Change: In section 3 (session tracker), add `delete session.files_read[normalizedFile]` immediately after updating `files_written`. This eagerly invalidates the read cache for the written file, so the very next re-read is treated as fresh without needing to compare mtimes at all.

---

## Acceptance criteria

- [ ] Claude reads `foo.ts` → Claude writes to `foo.ts` → Claude reads `foo.ts` again → **no repeated-read warning**, anatomy hint re-fires
- [ ] Claude reads `foo.ts` → user edits `foo.ts` externally → Claude reads `foo.ts` again → **no repeated-read warning** (mtime changed)
- [ ] Claude reads `foo.ts` → nothing changes → Claude reads `foo.ts` again → **repeated-read warning fires** (correct behaviour preserved)
- [ ] `repeated_reads_warned` counter is not incremented for legitimate re-reads
- [ ] `statSync` errors (deleted file, permission denied) do not crash the hook — they fall back to the original warn-on-reread behaviour

## How to test

1. `openwolf init` in a test project, open Claude Code
2. Ask Claude to read any source file — note the anatomy hit in stderr
3. Ask Claude to edit that same file, then read it again
4. **Expected:** no `⚡ OpenWolf: ... was already read` warning on the second read
5. Edge case: ask Claude to read the same file twice without any write between — **expected:** warning fires on the second read (regression check)
6. Edge case: externally `touch src/foo.ts` between two reads — **expected:** second read is treated as fresh

## Notes

- No schema changes
- No new dependencies added
- No server/API changes
- No breaking changes to existing consumers — `read_mtime` is an optional field; sessions without it (e.g. old `_session.json` files) fall back to the original behaviour because the `if (prev.read_mtime !== undefined)` guard is skipped
- `statSync` is already used in this file for the symbol-hint freshness check, so the import is not new
- The `post-write.ts` change adds `files_read` to the `SessionData` interface there (was only in `pre-read.ts`'s local interface) to make the delete type-safe