### PR TITLE
feat(cron): add configurable inference provider for AI tasks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,29 @@ Controls the daemon's task scheduler.
 | `heartbeat_interval_minutes` | `30` | Daemon health check frequency |
 | `use_claude_p` | `true` | Use `claude -p` (subscription) for AI-powered tasks |
 | `api_key_env` | `null` | Environment variable name for API key override. When `null`, uses `claude -p` OAuth credentials |
+| `provider` | `null` | Selects an inference provider for AI-powered tasks. When `null`, uses `claude -p` OAuth credentials |
+
+### `cron.provider`
+
+When set, AI-powered cron tasks (`ai_task`) run against a configured inference
+provider that exposes an Anthropic-compatible endpoint, instead of the default
+`claude -p` subscription credentials. The `claude` CLI is pointed at the
+provider's regional base URL and asked for the selected model.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `id` | — | Provider registry key. Supported: `minimax` |
+| `region` | `global_en` | Endpoint region. `minimax`: `global_en`, `cn_zh` |
+| `model` | provider default | Model to request. `minimax`: `MiniMax-M3`, `MiniMax-M2.7` |
+
+The provider API key is read from the provider's environment variable
+(`minimax`: `MINIMAX_API_KEY`). Example:
+
+```json
+"cron": {
+  "provider": { "id": "minimax", "region": "global_en", "model": "MiniMax-M3" }
+}
+```
 
 ## `memory`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,14 @@ provider's regional base URL and asked for the selected model.
 | `region` | `global_en` | Endpoint region. `minimax`: `global_en`, `cn_zh` |
 | `model` | provider default | Model to request. `minimax`: `MiniMax-M3`, `MiniMax-M2.7` |
 
+The registry also exposes model metadata for tooling and validation. Prices are
+in US dollars per million tokens.
+
+| Model | Context | Input / output | Cache read / write | Input modalities | Thinking modes |
+|-------|---------|----------------|--------------------|------------------|----------------|
+| `MiniMax-M3` | 1,000,000 | $0.60 / $2.40 | $0.12 / unavailable | text, image, video | adaptive, disabled |
+| `MiniMax-M2.7` | 204,800 | $0.30 / $1.20 | $0.06 / $0.375 | text | always on |
+
 The provider API key is read from the provider's environment variable
 (`minimax`: `MINIMAX_API_KEY`). Example:
 

--- a/src/daemon/cron-engine.ts
+++ b/src/daemon/cron-engine.ts
@@ -5,6 +5,7 @@ import cron from "node-cron";
 import { readJSON, writeJSON, readText, writeText, appendText } from "../utils/fs-safe.js";
 import { scanProject } from "../scanner/anatomy-scanner.js";
 import { detectWaste } from "../tracker/waste-detector.js";
+import { resolveProviderConfig, type ProviderConfig } from "./providers.js";
 import type { Logger } from "../utils/logger.js";
 
 interface CronAction {
@@ -104,6 +105,14 @@ export class CronEngine {
       path.join(this.wolfDir, "cron-manifest.json"),
       { version: 1, tasks: [] }
     );
+  }
+
+  private readProviderConfig(): ProviderConfig | null {
+    const config = readJSON<{ openwolf?: { cron?: { provider?: ProviderConfig | null } } }>(
+      path.join(this.wolfDir, "config.json"),
+      {}
+    );
+    return config.openwolf?.cron?.provider ?? null;
   }
 
   private readState(): CronState {
@@ -327,13 +336,31 @@ export class CronEngine {
     try {
       // Use spawnSync to pipe prompt via stdin — avoids command-line length limits on Windows
       // claude -p (no argument) reads prompt from stdin
-      // Strip ANTHROPIC_API_KEY so claude uses OAuth subscription credentials
-      // instead of a potentially depleted API key
       const env = { ...process.env };
-      delete env.ANTHROPIC_API_KEY;
+      const args = ["-p", "--output-format", "text"];
+
+      // A configured provider redirects the CLI at an Anthropic-compatible
+      // endpoint and model; otherwise the runner keeps its default behavior.
+      const resolved = resolveProviderConfig(this.readProviderConfig());
+      if (resolved) {
+        const apiKey = process.env[resolved.provider.apiKeyEnv];
+        if (!apiKey) {
+          throw new Error(
+            `${resolved.provider.name} provider selected but ${resolved.provider.apiKeyEnv} is not set.`
+          );
+        }
+        env.ANTHROPIC_BASE_URL = resolved.endpoint.anthropicBaseUrl;
+        env.ANTHROPIC_AUTH_TOKEN = apiKey;
+        delete env.ANTHROPIC_API_KEY;
+        args.push("--model", resolved.model);
+      } else {
+        // Strip ANTHROPIC_API_KEY so claude uses OAuth subscription credentials
+        // instead of a potentially depleted API key.
+        delete env.ANTHROPIC_API_KEY;
+      }
 
       const claudeBin = process.platform === "win32" ? "claude.cmd" : "claude";
-      const proc = spawnSync(claudeBin, ["-p", "--output-format", "text"], {
+      const proc = spawnSync(claudeBin, args, {
         input: fullPrompt,
         timeout: 120000,
         encoding: "utf-8",

--- a/src/daemon/providers.ts
+++ b/src/daemon/providers.ts
@@ -21,10 +21,23 @@ export interface ProviderEndpoint {
   openaiBaseUrl: string;
 }
 
+export interface ProviderPricingUsdPerMillionTokens {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number | null;
+}
+
+export type ProviderInputModality = "text" | "image" | "video";
+export type ProviderThinkingMode = "adaptive" | "disabled" | "always_on";
+
 export interface ProviderModel {
   id: string;
   /** Maximum combined input + output tokens the model accepts. */
   contextWindow: number;
+  pricingUsdPerMillionTokens: ProviderPricingUsdPerMillionTokens;
+  inputModalities: ProviderInputModality[];
+  thinking: ProviderThinkingMode[];
 }
 
 export interface InferenceProvider {
@@ -47,8 +60,30 @@ export const PROVIDERS: Record<string, InferenceProvider> = {
     apiKeyEnv: "MINIMAX_API_KEY",
     defaultModel: "MiniMax-M3",
     models: [
-      { id: "MiniMax-M3", contextWindow: 1_000_000 },
-      { id: "MiniMax-M2.7", contextWindow: 204_800 },
+      {
+        id: "MiniMax-M3",
+        contextWindow: 1_000_000,
+        pricingUsdPerMillionTokens: {
+          input: 0.6,
+          output: 2.4,
+          cacheRead: 0.12,
+          cacheWrite: null,
+        },
+        inputModalities: ["text", "image", "video"],
+        thinking: ["adaptive", "disabled"],
+      },
+      {
+        id: "MiniMax-M2.7",
+        contextWindow: 204_800,
+        pricingUsdPerMillionTokens: {
+          input: 0.3,
+          output: 1.2,
+          cacheRead: 0.06,
+          cacheWrite: 0.375,
+        },
+        inputModalities: ["text"],
+        thinking: ["always_on"],
+      },
     ],
     endpoints: [
       {

--- a/src/daemon/providers.ts
+++ b/src/daemon/providers.ts
@@ -1,0 +1,131 @@
+/**
+ * Inference provider registry for the cron AI task runner.
+ *
+ * The scheduled `ai_task` jobs drive the `claude` CLI, which speaks the
+ * Anthropic-compatible wire protocol. By default the runner relies on the CLI's
+ * OAuth subscription credentials. When a provider is selected in
+ * `.wolf/config.json` (`openwolf.cron.provider`), the runner instead points the
+ * CLI at that provider's Anthropic-compatible base URL and requests one of its
+ * models, so alternative backends can serve the scheduled tasks.
+ *
+ * Each provider ships the models it exposes and its regional endpoints, so a
+ * task can be pinned to a specific region without hard-coding a URL in config.
+ */
+
+export interface ProviderEndpoint {
+  /** Stable region key referenced by config (e.g. "global_en", "cn_zh"). */
+  region: string;
+  /** Anthropic-compatible base URL consumed by the `claude` CLI. */
+  anthropicBaseUrl: string;
+  /** OpenAI-compatible base URL for direct HTTP clients. */
+  openaiBaseUrl: string;
+}
+
+export interface ProviderModel {
+  id: string;
+  /** Maximum combined input + output tokens the model accepts. */
+  contextWindow: number;
+}
+
+export interface InferenceProvider {
+  /** Human-readable provider name. */
+  name: string;
+  /** Environment variable that holds the provider API key. */
+  apiKeyEnv: string;
+  /** Model requested when a task does not name one. */
+  defaultModel: string;
+  models: ProviderModel[];
+  endpoints: ProviderEndpoint[];
+}
+
+/** Region used when a provider is selected without naming one. */
+export const DEFAULT_REGION = "global_en";
+
+export const PROVIDERS: Record<string, InferenceProvider> = {
+  minimax: {
+    name: "MiniMax",
+    apiKeyEnv: "MINIMAX_API_KEY",
+    defaultModel: "MiniMax-M3",
+    models: [
+      { id: "MiniMax-M3", contextWindow: 1_000_000 },
+      { id: "MiniMax-M2.7", contextWindow: 204_800 },
+    ],
+    endpoints: [
+      {
+        region: "global_en",
+        anthropicBaseUrl: "https://api.minimax.io/anthropic",
+        openaiBaseUrl: "https://api.minimax.io/v1",
+      },
+      {
+        region: "cn_zh",
+        anthropicBaseUrl: "https://api.minimaxi.com/anthropic",
+        openaiBaseUrl: "https://api.minimaxi.com/v1",
+      },
+    ],
+  },
+};
+
+/** Selection block stored under `openwolf.cron.provider` in config.json. */
+export interface ProviderConfig {
+  /** Provider registry key (e.g. "minimax"). */
+  id?: string;
+  /** Endpoint region key; falls back to DEFAULT_REGION. */
+  region?: string;
+  /** Model id to request; falls back to the provider's default model. */
+  model?: string;
+}
+
+export interface ResolvedProvider {
+  provider: InferenceProvider;
+  endpoint: ProviderEndpoint;
+  model: string;
+}
+
+export function getProvider(id: string): InferenceProvider | undefined {
+  return PROVIDERS[id.trim().toLowerCase()];
+}
+
+export function getEndpoint(
+  provider: InferenceProvider,
+  region: string
+): ProviderEndpoint | undefined {
+  return provider.endpoints.find((e) => e.region === region);
+}
+
+/**
+ * Resolve a `provider` config block into a concrete provider, endpoint, and
+ * model. Returns `null` when no provider is selected (the runner then keeps its
+ * default subscription behavior). Throws when the provider, region, or model is
+ * named but unknown, so a misconfigured task fails loudly instead of silently
+ * running against the wrong backend.
+ */
+export function resolveProviderConfig(
+  config: ProviderConfig | undefined | null
+): ResolvedProvider | null {
+  if (!config || !config.id) return null;
+
+  const provider = getProvider(config.id);
+  if (!provider) {
+    const known = Object.keys(PROVIDERS).join(", ");
+    throw new Error(`Unknown inference provider "${config.id}" (known: ${known})`);
+  }
+
+  const region = config.region ?? DEFAULT_REGION;
+  const endpoint = getEndpoint(provider, region);
+  if (!endpoint) {
+    const known = provider.endpoints.map((e) => e.region).join(", ");
+    throw new Error(
+      `Unknown region "${region}" for provider ${provider.name} (known: ${known})`
+    );
+  }
+
+  const model = config.model ?? provider.defaultModel;
+  if (!provider.models.some((m) => m.id === model)) {
+    const known = provider.models.map((m) => m.id).join(", ");
+    throw new Error(
+      `Unknown model "${model}" for provider ${provider.name} (known: ${known})`
+    );
+  }
+
+  return { provider, endpoint, model };
+}

--- a/src/templates/config.json
+++ b/src/templates/config.json
@@ -42,7 +42,8 @@
       "dead_letter_enabled": true,
       "heartbeat_interval_minutes": 30,
       "use_claude_p": true,
-      "api_key_env": null
+      "api_key_env": null,
+      "provider": null
     },
     "memory": {
       "consolidation_after_days": 7,

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -51,10 +51,32 @@ describe("inference provider registry", () => {
     assert.deepStrictEqual(regions, ["cn_zh", "global_en"]);
   });
 
-  test("exposes both models with their context windows", () => {
-    const byId = new Map(PROVIDERS.minimax.models.map((m) => [m.id, m.contextWindow]));
-    assert.strictEqual(byId.get("MiniMax-M3"), 1_000_000);
-    assert.strictEqual(byId.get("MiniMax-M2.7"), 204_800);
+  test("exposes complete metadata for both models", () => {
+    const byId = new Map(PROVIDERS.minimax.models.map((model) => [model.id, model]));
+    assert.deepStrictEqual(byId.get("MiniMax-M3"), {
+      id: "MiniMax-M3",
+      contextWindow: 1_000_000,
+      pricingUsdPerMillionTokens: {
+        input: 0.6,
+        output: 2.4,
+        cacheRead: 0.12,
+        cacheWrite: null,
+      },
+      inputModalities: ["text", "image", "video"],
+      thinking: ["adaptive", "disabled"],
+    });
+    assert.deepStrictEqual(byId.get("MiniMax-M2.7"), {
+      id: "MiniMax-M2.7",
+      contextWindow: 204_800,
+      pricingUsdPerMillionTokens: {
+        input: 0.3,
+        output: 1.2,
+        cacheRead: 0.06,
+        cacheWrite: 0.375,
+      },
+      inputModalities: ["text"],
+      thinking: ["always_on"],
+    });
   });
 
   test("accepts an explicitly named supported model", () => {

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -1,0 +1,86 @@
+import { test, describe } from "node:test";
+import * as assert from "node:assert";
+
+import {
+  resolveProviderConfig,
+  getProvider,
+  getEndpoint,
+  PROVIDERS,
+  DEFAULT_REGION,
+} from "../src/daemon/providers.ts";
+
+describe("inference provider registry", () => {
+  test("no provider selected resolves to null", () => {
+    assert.strictEqual(resolveProviderConfig(null), null);
+    assert.strictEqual(resolveProviderConfig(undefined), null);
+    assert.strictEqual(resolveProviderConfig({}), null);
+  });
+
+  test("resolves the default region and model when only id is given", () => {
+    const resolved = resolveProviderConfig({ id: "minimax" });
+    assert.ok(resolved);
+    assert.strictEqual(resolved!.provider.name, "MiniMax");
+    assert.strictEqual(resolved!.endpoint.region, DEFAULT_REGION);
+    assert.strictEqual(resolved!.model, PROVIDERS.minimax.defaultModel);
+    assert.strictEqual(
+      resolved!.endpoint.anthropicBaseUrl,
+      "https://api.minimax.io/anthropic"
+    );
+  });
+
+  test("id lookup is case-insensitive and trims whitespace", () => {
+    assert.ok(getProvider("  MiniMax "));
+    const resolved = resolveProviderConfig({ id: "MINIMAX" });
+    assert.strictEqual(resolved!.provider.name, "MiniMax");
+  });
+
+  test("resolves the CN region endpoint", () => {
+    const resolved = resolveProviderConfig({ id: "minimax", region: "cn_zh" });
+    assert.strictEqual(
+      resolved!.endpoint.anthropicBaseUrl,
+      "https://api.minimaxi.com/anthropic"
+    );
+    assert.strictEqual(
+      resolved!.endpoint.openaiBaseUrl,
+      "https://api.minimaxi.com/v1"
+    );
+  });
+
+  test("both regions are registered for minimax", () => {
+    const regions = PROVIDERS.minimax.endpoints.map((e) => e.region).sort();
+    assert.deepStrictEqual(regions, ["cn_zh", "global_en"]);
+  });
+
+  test("exposes both models with their context windows", () => {
+    const byId = new Map(PROVIDERS.minimax.models.map((m) => [m.id, m.contextWindow]));
+    assert.strictEqual(byId.get("MiniMax-M3"), 1_000_000);
+    assert.strictEqual(byId.get("MiniMax-M2.7"), 204_800);
+  });
+
+  test("accepts an explicitly named supported model", () => {
+    const resolved = resolveProviderConfig({ id: "minimax", model: "MiniMax-M2.7" });
+    assert.strictEqual(resolved!.model, "MiniMax-M2.7");
+  });
+
+  test("throws on unknown provider", () => {
+    assert.throws(() => resolveProviderConfig({ id: "nope" }), /Unknown inference provider/);
+  });
+
+  test("throws on unknown region", () => {
+    assert.throws(
+      () => resolveProviderConfig({ id: "minimax", region: "mars" }),
+      /Unknown region/
+    );
+  });
+
+  test("throws on unknown model", () => {
+    assert.throws(
+      () => resolveProviderConfig({ id: "minimax", model: "MiniMax-Z9" }),
+      /Unknown model/
+    );
+  });
+
+  test("getEndpoint returns undefined for an unknown region", () => {
+    assert.strictEqual(getEndpoint(PROVIDERS.minimax, "nowhere"), undefined);
+  });
+});


### PR DESCRIPTION
Reason: The cron AI task runner is hard-wired to the `claude` CLI subscription with no way to select a configurable inference provider or its endpoints.

## What changed

- Add `src/daemon/providers.ts`: an inference provider registry. It ships a `MiniMax` entry exposing both of its models (`MiniMax-M3`, 1,000,000-token context; `MiniMax-M2.7`, 204,800-token context) and both regional endpoints (`global_en` and `cn_zh`), plus a `resolveProviderConfig` resolver that validates the selected provider, region, and model.
- Record each model's input/output and cache pricing, accepted input modalities, and thinking modes in the typed provider registry.
- Wire `runAiTask` in `src/daemon/cron-engine.ts` to honor an optional `openwolf.cron.provider` selection block. When set, the `claude` CLI is pointed at the provider's Anthropic-compatible base URL and asked for the selected model; the API key is read from `MINIMAX_API_KEY`. When unset, the existing subscription-credential behavior is unchanged.
- Add `"provider": null` to the `cron` block of the config template, preserving current behavior until a provider is configured.
- Document provider selection and the complete model metadata in `docs/configuration.md`.
- Add `tests/providers.test.ts` coverage for resolution, both regions and models, complete model metadata, case-insensitive ids, and invalid selections.

## Checks

- `pnpm test`
- `pnpm exec tsc --noEmit`
- `git diff --check`