### PR TITLE
fix(anatomy): stop silently dropping entries — tolerant parse + symlink-safe section keys

### DIFF
--- a/src/hooks/anatomy-store.ts
+++ b/src/hooks/anatomy-store.ts
@@ -116,12 +116,18 @@ export function parseAnatomy(content: string): Map<string, AnatomyEntry[]> {
       continue;
     }
     if (!currentSection) continue;
-    const em = line.match(/^- `([^`]+)`(?:\s+—\s+(.+?))?\s*\(~(\d+)\s+tok\)$/);
+    // Tolerant on purpose. anatomy.md is re-rendered from what this parses, and
+    // importFromMarkdown() reads hand-edits through it, so an entry this regex cannot
+    // match is invisible: the human's wording is ignored and the line disappears on the
+    // next render. Requiring BOTH an em-dash separator AND a trailing "(~N tok)" meant a
+    // plain hyphen, or an entry written without a token estimate, was silently dropped.
+    // Accept any of — – - : as the separator and treat the token estimate as optional.
+    const em = line.match(/^- `([^`]+)`\s*(?:[—–\-:]\s*(.*?))?\s*(?:\(~(\d+)\s*tok\))?\s*$/);
     if (em) {
       sections.get(currentSection)!.push({
         file: em[1],
-        description: em[2] || "",
-        tokens: parseInt(em[3], 10),
+        description: (em[2] || "").trim(),
+        tokens: em[3] ? parseInt(em[3], 10) : 0,
       });
     }
   }

--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -4,7 +4,8 @@ import * as crypto from "node:crypto";
 import {
   getWolfDir, ensureWolfDir, readJSON, writeJSON, readMarkdown,
   extractDescription, estimateTokens, appendMarkdown, timeShort, readStdin, normalizePath,
-  isSensitiveFile, getProjectDir
+  isSensitiveFile, getProjectDir,
+  realPath,
 } from "./shared.js";
 import { loadStoreReconciled, saveStore, renderToFile, sha256 } from "./anatomy-store.js";
 import { withAnatomyLock, HOOK_LOCK_BUDGET_MS } from "./anatomy-lock.js";
@@ -68,7 +69,17 @@ async function main(): Promise<void> {
   const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(projectRoot, filePath);
 
   // Skip processing for .wolf/ internal files to avoid slow self-referential updates
-  const relPath = normalizePath(path.relative(projectRoot, absolutePath));
+  // Resolve symlinks/junctions FIRST, or the outside-root guard below can be bypassed.
+  // On Windows a directory junction can expose the same tree under a second drive letter
+  // (e.g. C:\project -> D:\project). Reached through the junction, path.relative() cannot
+  // produce a relative path across drives and returns an ABSOLUTE one, which does not start
+  // with ".." — so the guard misses it and an absolute "C:/..." section key is written into
+  // anatomy.md, the very churn that guard exists to prevent. Resolving first makes both
+  // spellings agree. Resolution is also what stops one physical directory being indexed
+  // under several keys, which additionally defeats pre-read's section lookup.
+  const realAbsolute = realPath(absolutePath);
+  const realRoot = realPath(projectRoot);
+  const relPath = normalizePath(path.relative(realRoot, realAbsolute));
   if (relPath.startsWith(".wolf/")) { process.exit(0); return; }
 
   // Never track files outside the project root (e.g. the Claude Code scratchpad under
@@ -88,7 +99,7 @@ async function main(): Promise<void> {
   //    All of this happens under the anatomy lock; if the lock cannot be
   //    acquired within budget we skip — a later writer converges the state.
   try {
-    const relPathLocal = normalizePath(path.relative(projectRoot, absolutePath));
+    const relPathLocal = normalizePath(path.relative(realRoot, realAbsolute));
 
     let fileContent = "";
     try {

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -573,6 +573,22 @@ export function readStdin(): Promise<string> {
   });
 }
 
+/**
+ * Resolve symlinks and junctions so one physical path always has one identity.
+ *
+ * Needed before any path is turned into an anatomy section key or compared against the
+ * project root: on Windows a directory junction can expose the same tree under a second
+ * drive letter, and path.relative() cannot relativise across drives, so it silently returns
+ * an ABSOLUTE path instead. Falls back to the input when the path does not exist yet.
+ */
+export function realPath(p: string): string {
+  try {
+    return fs.realpathSync.native(p);
+  } catch {
+    return p;
+  }
+}
+
 export function normalizePath(p: string): string {
   return p.replace(/\\/g, "/");
 }

--- a/tests/anatomy-parse-tolerance.test.ts
+++ b/tests/anatomy-parse-tolerance.test.ts
@@ -1,0 +1,62 @@
+import { test, describe } from "node:test";
+import * as assert from "node:assert";
+
+import { parseAnatomy } from "../src/hooks/anatomy-store.ts";
+
+/**
+ * anatomy.md is re-rendered from whatever parseAnatomy() understands, and importFromMarkdown()
+ * reads hand-edits through the same parser. An entry the regex cannot match is therefore not
+ * merely ignored — it is deleted on the next render, taking any curated description with it.
+ *
+ * The original pattern required BOTH an em-dash separator AND a trailing "(~N tok)", so an
+ * entry written with a plain hyphen, or without a token estimate, silently vanished.
+ */
+describe("parseAnatomy tolerance", () => {
+  const md = [
+    "# anatomy.md",
+    "",
+    "## scripts/",
+    "",
+    "- `emdash.py` — canonical shape (~120 tok)",
+    "- `hyphen.py` - plain hyphen separator (~120 tok)",
+    "- `endash.py` – en dash separator (~120 tok)",
+    "- `colon.py`: colon separator (~120 tok)",
+    "- `notok.py` — no token estimate",
+    "- `bare.py` (~55 tok)",
+    "",
+  ].join("\n");
+
+  const sections = parseAnatomy(md);
+  const entries = sections.get("scripts/") ?? [];
+  const byFile = new Map(entries.map((e) => [e.file, e]));
+
+  test("keeps every reasonable entry shape", () => {
+    assert.equal(entries.length, 6, `expected 6 entries, got ${entries.length}`);
+  });
+
+  for (const f of ["emdash.py", "hyphen.py", "endash.py", "colon.py", "notok.py", "bare.py"]) {
+    test(`keeps ${f}`, () => assert.ok(byFile.has(f), `${f} was dropped by the parser`));
+  }
+
+  test("preserves the description text", () => {
+    assert.equal(byFile.get("hyphen.py")?.description, "plain hyphen separator");
+    assert.equal(byFile.get("notok.py")?.description, "no token estimate");
+  });
+
+  test("treats a missing token estimate as zero rather than dropping the entry", () => {
+    assert.equal(byFile.get("notok.py")?.tokens, 0);
+  });
+
+  test("an entry with no description still parses", () => {
+    assert.equal(byFile.get("bare.py")?.description, "");
+    assert.equal(byFile.get("bare.py")?.tokens, 55);
+  });
+
+  test("descriptions containing separators and parentheses survive intact", () => {
+    const tricky = parseAnatomy(
+      "## s/\n\n- `x.py` — does A — then B (see notes): done (~10 tok)\n"
+    ).get("s/")![0];
+    assert.equal(tricky.description, "does A — then B (see notes): done");
+    assert.equal(tricky.tokens, 10);
+  });
+});


### PR DESCRIPTION
Two ways `anatomy.md` loses entries, plus one opt-in that I'm happy to drop.

Found while debugging a vault where `anatomy.md` had decayed to **7 entries under 840 empty section headings**, with every hand-written description gone. Both fixes are independent; the third commit is a feature that reverses a deliberate design decision, so please treat it separately.

### 1. `parseAnatomy()` silently deletes entries it can't match

`anatomy.md` is re-rendered from whatever `parseAnatomy()` understands, and `importFromMarkdown()` absorbs hand-edits through the same parser. So an entry the regex can't match isn't merely ignored — it disappears on the next render, taking any curated description with it.

The pattern required **both** an em-dash separator **and** a trailing `(~N tok)`:

```js
/^- `([^`]+)`(?:\s+—\s+(.+?))?\s*\(~(\d+)\s+tok\)$/
```

So these were all dropped:

```
- `hyphen.py` - plain hyphen separator (~120 tok)
- `endash.py` – en dash separator (~120 tok)
- `colon.py`: colon separator (~120 tok)
- `notok.py` — no token estimate
```

A human editing `anatomy.md` by hand — which the docs encourage — has no way to know the separator is load-bearing. Now any dash/colon separator is accepted and the token estimate is optional (missing becomes `0` rather than a deleted entry).

`tests/anatomy-parse-tolerance.test.ts` **fails 7 of its 11 assertions against the old regex and passes 11 of 11 against the new one**, so it demonstrably pins the bug rather than just passing.

### 2. A symlink or junction bypasses the outside-root guard

`post-write` skips files whose path relative to the project root starts with `..`, with the comment that such keys "are wiped again by every full `openwolf scan`, so the index churns instead of converging". Agreed — but a directory symlink or Windows junction defeats the check.

When the same tree is reachable under a second drive letter (`C:\project` → `D:\project`), `path.relative()` cannot relativise across drives and returns an **absolute** path instead. That doesn't start with `..`, so the guard passes it through and an absolute `C:/...` section key lands in `anatomy.md` — exactly the churn the guard exists to prevent.

It compounds: one physical directory ends up with several keys (relative, absolute, and case variants on case-insensitive filesystems). Since `pre-read` matches section keys case-sensitively, entries stop matching the files they describe, and anatomy quietly stops saving reads — the whole point of the index. In our case one directory had five keys and every lookup missed.

Fix: resolve with `fs.realpathSync.native()` before computing the relative path, so every spelling agrees and the existing guard works as intended. Adds `realPath()` to `hooks/shared.ts`, falling back to its input for paths that don't exist yet.

### 3. `openwolf scan --include <dir...>` — separable, drop if unwanted

Opt-in; default behaviour unchanged.

Walking only the project root is right for a single repository. Some projects span trees: ours has a planning/docs vault beside the code repositories it describes, and our house rule is to consult anatomy before opening any project file. Without this the two halves fight — the write hook adds entries for the sibling tree, and the next full scan removes them.

Extra roots are walked with their own base so keys stay stable rather than depending on which tree a file was reached through; they share the `max_files` budget; a non-existent path is warned about and skipped.

**This reverses a deliberate decision rather than fixing a bug**, so it's the last commit and easy to drop. The two fixes stand on their own, and I'd rather land those than argue for this.

### Verification

- Full suite: **37 tests, 37 pass.**
- `tsc --noEmit`: only the pre-existing `src/daemon/cron-engine.ts` TS2503 `cron` namespace error, which is present on a clean checkout of `main` too — untouched by these commits.
- No lockfile changes (the `package-lock.json` a local `npm install` produced was deliberately excluded; the project builds with pnpm).

Happy to split this into separate PRs, reword, or drop the third commit — whatever's easiest to review.
