### PR TITLE
fix(session): scope write tracking by session, and stop wiping live sessions

### DIFF
--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -22,7 +22,7 @@ const NON_CODE_EXTS = new Set([
 ]);
 
 interface SessionData {
-  files_written: Array<{ file: string; action: string; tokens: number; at: string }>;
+  files_written: Array<{ file: string; action: string; tokens: number; at: string; sid?: string }>;
   edit_counts: Record<string, number>;
   [key: string]: unknown;
 }
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
   const projectRoot = getProjectDir();
 
   const raw = await readStdin();
-  let input: { tool_name?: string; tool_input?: { file_path?: string; path?: string; content?: string; old_string?: string; new_string?: string } };
+  let input: { tool_name?: string; session_id?: string; tool_input?: { file_path?: string; path?: string; content?: string; old_string?: string; new_string?: string } };
   try {
     input = JSON.parse(raw);
   } catch {
@@ -167,14 +167,22 @@ async function main(): Promise<void> {
     const fileContent = input.tool_input?.content ?? "";
     const tokens = estimateTokens(fileContent || newStr, "code");
 
+    // `_session.json` is ONE file per project, shared by every concurrent session, so a
+    // record with no owner belongs to everybody: "Session end: N writes across M files"
+    // reported the union of all live sessions, and the 3-edits reminder named files the
+    // current session had never opened. The harness supplies a session_id on every hook
+    // payload; stamping it is the whole fix, and stop.ts filters on it.
+    const sid = String(input.session_id ?? "unknown");
+
     session.files_written.push({
       file: normalizedFile,
       action,
       tokens,
       at: new Date().toISOString(),
+      sid,
     });
 
-    const editKey = normalizePath(path.relative(projectRoot, absolutePath));
+    const editKey = sid + "::" + normalizePath(path.relative(projectRoot, absolutePath));
     session.edit_counts[editKey] = (session.edit_counts[editKey] || 0) + 1;
 
     writeJSON(sessionFile, session);

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -11,6 +11,15 @@ import { loadStore } from "./anatomy-store.js";
 // the SessionStart additionalContext channel — capped to a per-agent token
 // budget so injection cost stays fixed and predictable.
 
+/** One recorded write. `sid` names the owning harness session (see post-write.ts). */
+interface FileWrite {
+  file: string;
+  action: string;
+  tokens: number;
+  at: string;
+  sid?: string;
+}
+
 interface ContextConfig {
   session_digest_budget_tokens?: number;
   budgets?: Record<string, number>;
@@ -122,19 +131,53 @@ async function main(): Promise<void> {
   // still live, and resetting _session.json would wipe read/write tracking
   // mid-flight (Workstream F3: compaction survival).
   let source = "startup";
+  let hookSessionId = "";
   try {
     const hookInput = JSON.parse(await readStdin());
     if (typeof hookInput.source === "string") source = hookInput.source;
+    if (typeof hookInput.session_id === "string") hookSessionId = hookInput.session_id;
   } catch {}
   const continuing = (source === "compact" || source === "resume") && fs.existsSync(sessionFile);
+
+  // `_session.json` is shared by every concurrent session, so resetting it wholesale here
+  // deletes the history of every session that is already running — and with several agents
+  // open at once, that is whenever anyone starts one. Scoping the records by session id is
+  // pointless without this: they would be scoped and then thrown away before being read.
+  //
+  // Only OTHER sessions' records are carried, and the bound on growth is deliberately
+  // generous on both axes, because a bound that exists to cap a file must not become a way
+  // to lose live data: 48h (a session running longer is implausible; 12h is not) and a
+  // count ceiling far above any real concurrent load, applied newest-first.
+  const CARRY_MS = 48 * 60 * 60 * 1000;
+  const CARRY_MAX = 5000;
+  const { carriedWrites, carriedEditCounts } = (() => {
+    try {
+      const prev = readJSON<{ files_written?: FileWrite[]; edit_counts?: Record<string, number> }>(sessionFile, {});
+      const cutoff = Date.now() - CARRY_MS;
+      let writes = (prev.files_written ?? []).filter(
+        (w) => w && w.sid && w.sid !== hookSessionId && Date.parse(w.at || "") >= cutoff
+      );
+      if (writes.length > CARRY_MAX) writes = writes.slice(-CARRY_MAX);
+      // edit_counts keys are `<sid>::<relpath>` and carry no timestamp, so their liveness
+      // comes from the writes above: a session with no recent write has no live count.
+      const live = new Set(writes.map((w) => w.sid));
+      const counts: Record<string, number> = {};
+      for (const [k, v] of Object.entries(prev.edit_counts ?? {})) {
+        if (live.has(String(k).split("::")[0])) counts[k] = v;
+      }
+      return { carriedWrites: writes, carriedEditCounts: counts };
+    } catch {
+      return { carriedWrites: [] as FileWrite[], carriedEditCounts: {} as Record<string, number> };
+    }
+  })();
 
   if (!continuing) {
     writeJSON(sessionFile, {
       session_id: sessionId,
       started: timestamp(),
       files_read: {},
-      files_written: [],
-      edit_counts: {},
+      files_written: carriedWrites,
+      edit_counts: carriedEditCounts,
       anatomy_hits: 0,
       anatomy_misses: 0,
       repeated_reads_warned: 0,

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -13,6 +13,8 @@ interface FileWrite {
   action: string;
   tokens: number;
   at: string;
+  /** Owning harness session. Absent on records written before session scoping existed. */
+  sid?: string;
 }
 
 interface SessionData {
@@ -57,7 +59,7 @@ async function main(): Promise<void> {
   const sessionFile = path.join(hooksDir, "_session.json");
 
   // Stop payload → transcript path for real usage measurement (F1)
-  let hookInput: { transcript_path?: string } = {};
+  let hookInput: { transcript_path?: string; session_id?: string } = {};
   try {
     hookInput = JSON.parse(await readStdin());
   } catch {}
@@ -77,9 +79,17 @@ async function main(): Promise<void> {
 
   session.stop_count++;
 
+  // Every question below is "what did THIS session do", and `_session.json` is shared by
+  // every concurrent session — so each was answering with everyone's data. Scope once here
+  // and pass the result down. Never assign it back onto `session`: this object is written
+  // back to the shared file, so narrowing it in place would DELETE the other live sessions'
+  // records, which is the very thing being fixed.
+  const mySid = String(hookInput.session_id || session.session_id || "");
+  const myWrites = writesFor(session, mySid);
+
   // Only write to ledger if there's been activity
   const readCount = Object.keys(session.files_read).length;
-  const writeCount = session.files_written.length;
+  const writeCount = myWrites.length;
 
   if (readCount === 0 && writeCount === 0) {
     writeJSON(sessionFile, session);
@@ -89,13 +99,13 @@ async function main(): Promise<void> {
 
   // Collect end-of-turn reminders — returned as strings, then surfaced via additionalContext
   const reminders = [
-    checkForMissingBugLogs(wolfDir, session),
-    checkCerebrumFreshness(wolfDir, session),
-    checkSemanticSummaries(wolfDir, session),
+    checkForMissingBugLogs(wolfDir, session, myWrites),
+    checkCerebrumFreshness(wolfDir, session, myWrites),
+    checkSemanticSummaries(wolfDir, session, myWrites),
   ].filter((r): r is string => r !== null);
 
   // Check if STATUS.md is stale relative to this session
-  checkStatusFreshness(wolfDir, session);
+  checkStatusFreshness(wolfDir, session, myWrites);
 
   // Build session entry for ledger
   const reads = Object.entries(session.files_read).map(([file, data]) => ({
@@ -105,7 +115,7 @@ async function main(): Promise<void> {
     anatomy_had_description: false, // simplified
   }));
 
-  const writes = session.files_written.map((w) => ({
+  const writes = myWrites.map((w) => ({
     file: w.file,
     tokens_estimated: w.tokens,
     action: w.action,
@@ -191,7 +201,7 @@ async function main(): Promise<void> {
   // Write a session summary line to memory.md if there was meaningful activity
   if (writeCount > 0) {
     try {
-      const uniqueFiles = new Set(session.files_written.map(w => path.basename(w.file)));
+      const uniqueFiles = new Set(myWrites.map(w => path.basename(w.file)));
       const fileList = [...uniqueFiles].slice(0, 5).join(", ");
       const memoryPath = path.join(wolfDir, "memory.md");
       appendMarkdown(memoryPath, `| ${timeShort()} | Session end: ${writeCount} writes across ${uniqueFiles.size} files (${fileList}) | ${readCount} reads | ~${inputTokens + outputTokens} tok |\n`);
@@ -215,7 +225,20 @@ async function main(): Promise<void> {
  * Check if files were edited multiple times but buglog.json wasn't updated.
  * Returns a reminder string if action is needed, otherwise null.
  */
-function checkForMissingBugLogs(wolfDir: string, session: SessionData): string | null {
+/**
+ * This session's writes only.
+ *
+ * Records written before session scoping existed carry no `sid` and are ignored rather than
+ * shared out: attributing an unowned record to every session is precisely the defect. The
+ * population is self-clearing, since post-write now stamps every record.
+ */
+function writesFor(session: SessionData, sid: string): FileWrite[] {
+  const all = Array.isArray(session.files_written) ? session.files_written : [];
+  if (!sid) return all;
+  return all.filter((w) => w && w.sid === sid);
+}
+
+function checkForMissingBugLogs(wolfDir: string, session: SessionData, myWrites: FileWrite[]): string | null {
   if (!session.edit_counts) return null;
 
   const multiEditFiles = Object.entries(session.edit_counts)
@@ -224,7 +247,7 @@ function checkForMissingBugLogs(wolfDir: string, session: SessionData): string |
 
   if (multiEditFiles.length === 0) return null;
 
-  const buglogWritten = session.files_written.some(w =>
+  const buglogWritten = myWrites.some(w =>
     w.file.includes("buglog.json")
   );
 
@@ -239,9 +262,9 @@ function checkForMissingBugLogs(wolfDir: string, session: SessionData): string |
  * code activity (3+ writes outside .wolf/). If so, nudge Claude to update
  * STATUS.md so the next /clear has fresh handoff context.
  */
-function checkStatusFreshness(wolfDir: string, session: SessionData): void {
+function checkStatusFreshness(wolfDir: string, session: SessionData, myWrites: FileWrite[]): void {
   const statusPath = path.join(wolfDir, "STATUS.md");
-  const codeWrites = session.files_written.filter(
+  const codeWrites = myWrites.filter(
     (w) => !w.file.includes("/.wolf/") && !w.file.endsWith(".tmp")
   );
 
@@ -269,14 +292,14 @@ function checkStatusFreshness(wolfDir: string, session: SessionData): void {
  * Check if cerebrum.md was updated recently. If it hasn't been updated in
  * a while and there was significant activity, return a reminder.
  */
-function checkCerebrumFreshness(wolfDir: string, session: SessionData): string | null {
+function checkCerebrumFreshness(wolfDir: string, session: SessionData, myWrites: FileWrite[]): string | null {
   const cerebrumPath = path.join(wolfDir, "cerebrum.md");
   try {
     const stat = fs.statSync(cerebrumPath);
     const hoursSinceUpdate = (Date.now() - stat.mtimeMs) / (1000 * 60 * 60);
 
-    if (hoursSinceUpdate > 24 && session.files_written.length >= 3) {
-      return `ACTION REQUIRED: cerebrum.md hasn't been updated in ${Math.floor(hoursSinceUpdate)}h and ${session.files_written.length} files were modified. Update .wolf/cerebrum.md with any new user preferences, conventions, or gotchas discovered this session.`;
+    if (hoursSinceUpdate > 24 && myWrites.length >= 3) {
+      return `ACTION REQUIRED: cerebrum.md hasn't been updated in ${Math.floor(hoursSinceUpdate)}h and ${myWrites.length} files were modified. Update .wolf/cerebrum.md with any new user preferences, conventions, or gotchas discovered this session.`;
     }
   } catch {
     // cerebrum.md doesn't exist, that's ok
@@ -288,8 +311,8 @@ function checkCerebrumFreshness(wolfDir: string, session: SessionData): string |
  * Check if a semantic summary was written to memory.md this session.
  * Returns a reminder string if action is needed, otherwise null.
  */
-function checkSemanticSummaries(wolfDir: string, session: SessionData): string | null {
-  const writeCount = session.files_written.length;
+function checkSemanticSummaries(wolfDir: string, session: SessionData, myWrites: FileWrite[]): string | null {
+  const writeCount = myWrites.length;
   if (writeCount < 2) return null;
 
   const semanticCount = countSemanticEntries(wolfDir);

--- a/tests/session-write-scoping.test.ts
+++ b/tests/session-write-scoping.test.ts
@@ -1,0 +1,160 @@
+import { test, describe } from "node:test";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Drives the real hooks as child processes, the way the harness runs them, because the
+ * defect is about what several PROCESSES sharing `_session.json` do to each other — it does
+ * not reproduce inside one process.
+ *
+ * Hooks are loaded from `dist/` (built on demand): they import each other with relative
+ * `.js` specifiers, which type-stripping does not rewrite.
+ */
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const distHooks = path.join(repoRoot, "dist", "src", "hooks");
+if (!fs.existsSync(path.join(distHooks, "stop.js"))) {
+  try {
+    execSyncBuild();
+  } catch {}
+  if (!fs.existsSync(path.join(distHooks, "stop.js"))) throw new Error("build produced no dist/src/hooks");
+}
+function execSyncBuild() {
+  // tsc exits non-zero on the pre-existing cron-engine TS2503 but still emits, so the
+  // emitted file decides success, not the exit code.
+  spawnSync("npx", ["tsc", "-p", "tsconfig.json"], { cwd: repoRoot, stdio: "ignore", shell: true });
+}
+
+const A = "sid-aaaa", B = "sid-bbbb", C = "sid-cccc";
+const iso = (msAgo: number) => new Date(Date.now() - msAgo).toISOString();
+
+function makeProject(session: Record<string, unknown>) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "wolf-scope-"));
+  const hooks = path.join(root, ".wolf", "hooks");
+  fs.mkdirSync(hooks, { recursive: true });
+  fs.mkdirSync(path.join(root, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, ".wolf", "memory.md"),
+    "# memory\n\n| Time | Action | File(s) | Outcome | ~Tokens |\n|---|---|---|---|---|\n",
+    "utf-8"
+  );
+  fs.writeFileSync(path.join(hooks, "_session.json"), JSON.stringify(session), "utf-8");
+  return { root, sessionFile: path.join(hooks, "_session.json") };
+}
+function runHook(p: { root: string }, hook: string, payload: unknown) {
+  return spawnSync(process.execPath, [path.join(distHooks, hook)], {
+    input: JSON.stringify(payload),
+    encoding: "utf-8",
+    env: { ...process.env, CLAUDE_PROJECT_DIR: p.root },
+  });
+}
+const readSession = (p: { sessionFile: string }) =>
+  JSON.parse(fs.readFileSync(p.sessionFile, "utf-8")) as {
+    files_written?: Array<{ sid?: string; file: string }>;
+    edit_counts?: Record<string, number>;
+  };
+
+const baseSession = (writes: unknown[] = [], edit_counts: Record<string, number> = {}) => ({
+  session_id: A,
+  started: iso(3_600_000),
+  files_read: {},
+  files_written: writes,
+  edit_counts,
+  anatomy_hits: 0,
+  anatomy_misses: 0,
+  repeated_reads_warned: 0,
+  cerebrum_warnings: 0,
+  stop_count: 0,
+});
+const write = (sid: string, file: string, msAgo = 1000) => ({
+  file,
+  action: "edit",
+  tokens: 5,
+  at: iso(msAgo),
+  sid,
+});
+
+describe("write tracking is scoped to the owning session", () => {
+  test("post-write stamps the harness session id on each record", () => {
+    const p = makeProject(baseSession());
+    const target = path.join(p.root, "src", "x.py");
+    fs.writeFileSync(target, "x = 1\n", "utf-8");
+    runHook(p, "post-write.js", {
+      session_id: A,
+      tool_name: "Write",
+      tool_input: { file_path: target, content: "x = 1\n" },
+    });
+    const rec = (readSession(p).files_written ?? [])[0];
+    assert.ok(rec, "post-write recorded nothing");
+    assert.equal(rec.sid, A, "record has no owner, so it belongs to every session");
+    fs.rmSync(p.root, { recursive: true, force: true });
+  });
+
+  test("stop counts only its own writes, and deletes nobody else's", () => {
+    const p = makeProject(
+      baseSession([
+        write(A, "src/mine1.py"),
+        write(A, "src/mine2.py"),
+        write(B, "src/theirs1.py"),
+        write(B, "src/theirs2.py"),
+        write(B, "src/theirs3.py"),
+      ])
+    );
+    runHook(p, "stop.js", { session_id: A });
+
+    const memory = fs.readFileSync(path.join(p.root, ".wolf", "memory.md"), "utf-8");
+    const row = memory.split("\n").find((l) => l.includes("Session end:")) ?? "";
+    assert.match(row, /Session end: 2 writes/, `reported the union, not this session: ${row}`);
+    assert.equal(
+      (readSession(p).files_written ?? []).length,
+      5,
+      "reading the scoped view must not persist it — that would delete the other session"
+    );
+    fs.rmSync(p.root, { recursive: true, force: true });
+  });
+
+  test("a new session does not wipe a live session's history", () => {
+    const p = makeProject(
+      baseSession(
+        [
+          write(A, "src/live.py", 60_000), // live
+          write(A, "src/long.py", 13 * 3_600_000), // 13h — long-running, must survive
+          write(B, "src/dead.py", 50 * 3_600_000), // >48h — genuinely dead
+          write(C, "src/own.py", 60_000), // the starting session's own
+        ],
+        { [`${A}::src/live.py`]: 2, [`${B}::src/dead.py`]: 9 }
+      )
+    );
+    runHook(p, "session-start.js", { session_id: C, source: "startup" });
+
+    const after = readSession(p);
+    const sids = (after.files_written ?? []).map((w) => w.sid);
+    assert.equal(sids.filter((s) => s === A).length, 2, "dropped a live session's records");
+    assert.ok(!sids.includes(B), "kept a >48h record; growth is unbounded");
+    assert.ok(!sids.includes(C), "kept the starting session's own stale record");
+    const counts = Object.keys(after.edit_counts ?? {});
+    assert.ok(counts.some((k) => k.startsWith(A)));
+    assert.ok(!counts.some((k) => k.startsWith(B)));
+    fs.rmSync(p.root, { recursive: true, force: true });
+  });
+
+  test("edit_counts are namespaced, so the 3-edit reminder cannot count another session", () => {
+    const p = makeProject(baseSession());
+    const target = path.join(p.root, "src", "y.py");
+    fs.writeFileSync(target, "y = 1\n", "utf-8");
+    for (const sid of [A, A, B]) {
+      runHook(p, "post-write.js", {
+        session_id: sid,
+        tool_name: "Edit",
+        tool_input: { file_path: target, old_string: "y", new_string: "z" },
+      });
+    }
+    const counts = readSession(p).edit_counts ?? {};
+    assert.equal(Object.values(counts).filter((n) => n === 2).length, 1, JSON.stringify(counts));
+    assert.equal(Object.keys(counts).length, 2, "one key per (session, file), not per file");
+    fs.rmSync(p.root, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
`.wolf/hooks/_session.json` is one file per project, shared by every concurrent session. Two consequences, and the second is why the first was never visible.

**1. Records carry no owner.** Every "Session end: N writes across M files" row in memory.md reports the **union** of all live sessions. The same applies to the cerebrum-freshness and semantic-summary thresholds, the STATUS-freshness check, and the token ledger — each asks "what did *this* session do" and was answered with everyone's data. `edit_counts` is keyed by path alone, so the "edited 3+ times" reminder names files the current session never opened.

**2. `session-start` resets `files_written` and `edit_counts`** whenever a non-continuing session starts — which, with several agents open, is whenever anyone starts one. That deletes the history of every session already running. Scoping alone would have been cosmetic: the records would be attributed correctly and then thrown away before anything read them.

### The change

- `post-write` stamps each record with the harness `session_id` and namespaces the `edit_counts` key with it.
- `stop` scopes once at the top and passes the result down — deliberately **not** assigning it back onto `session`, because that object is written back to the shared file, so narrowing it in place would delete the other sessions' records and cause the very thing being fixed.
- `session-start` carries other sessions' records across the reset. The bound on growth is deliberately generous on both axes, because a bound whose job is to cap a file must not become a way to lose live data: 48h (a session running longer is implausible; 12h is not) and a count ceiling far above any real concurrent load, newest-first. `edit_counts` keys have no timestamp, so liveness is derived from whether their session still has a carried write.

Records predating this carry no `sid` and are ignored rather than shared out — attributing an unowned record to every session is precisely the defect, and the population is self-clearing once `post-write` stamps them.

### Verification

- `node --test tests/session-write-scoping.test.ts` — **4/4**
- `npm test` — **30/30**, 0 fail
- `npx tsc --noEmit` — clean apart from the pre-existing `src/daemon/cron-engine.ts(52,27) TS2503`
- `git am` onto pristine `main` (`f64e737`) applies cleanly, suite still 30/30
- **Control:** reverting the three sources and rebuilding makes **all four cases fail**

The test drives the real hooks as child processes — none of this reproduces inside a single process, since the whole defect is about what several processes sharing one file do to each other. Like #70 it loads from `dist/` and builds on demand, because the hooks import each other with relative `.js` specifiers that type-stripping does not rewrite; same open question for you there.

Independent of #66, #69 and #70 — cut from `main`, depends on none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)