### PR TITLE
Fix dashboard rendering for nullable cron state

### DIFF
--- a/src/dashboard/app/hooks/useWolfData.ts
+++ b/src/dashboard/app/hooks/useWolfData.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { dashboardFetch, WolfClient } from "../lib/wolf-client.js";
-import { parseAnatomy, parseMemory, parseCerebrum } from "../lib/file-parsers.js";
-import type { AnatomyEntry, MemorySession, CerebrumData } from "../lib/file-parsers.js";
+import { parseAnatomy, parseMemory, parseCerebrum, parseCronState } from "../lib/file-parsers.js";
+import type { AnatomyEntry, MemorySession, CerebrumData, CronState } from "../lib/file-parsers.js";
 
 export interface RealUsage {
   input_tokens: number;
@@ -103,13 +103,6 @@ export interface ScanState {
   file_count?: number;
 }
 
-interface CronState {
-  engine_status: string;
-  last_heartbeat: string | null;
-  execution_log: any[];
-  dead_letter_queue: any[];
-}
-
 interface BugLog {
   bugs: any[];
 }
@@ -205,7 +198,7 @@ export function useWolfData(): WolfData {
       try { setTokenLedger(JSON.parse(files["token-ledger.json"])); } catch {}
     }
     if (files["cron-state.json"]) {
-      try { setCronState(JSON.parse(files["cron-state.json"])); } catch {}
+      try { setCronState(parseCronState(files["cron-state.json"])); } catch {}
     }
     if (files["cron-manifest.json"]) {
       try { setCronManifest(JSON.parse(files["cron-manifest.json"])); } catch {}

--- a/src/dashboard/app/lib/file-parsers.ts
+++ b/src/dashboard/app/lib/file-parsers.ts
@@ -30,6 +30,23 @@ export interface CerebrumData {
   lastUpdated: string;
 }
 
+export interface CronState {
+  engine_status: string;
+  last_heartbeat: string | null;
+  execution_log: any[];
+  dead_letter_queue: any[];
+}
+
+export function parseCronState(content: string): CronState {
+  const state = JSON.parse(content);
+  return {
+    engine_status: state?.engine_status ?? "unknown",
+    last_heartbeat: state?.last_heartbeat ?? null,
+    execution_log: Array.isArray(state?.execution_log) ? state.execution_log : [],
+    dead_letter_queue: Array.isArray(state?.dead_letter_queue) ? state.dead_letter_queue : [],
+  };
+}
+
 export function parseAnatomy(content: string): { entries: AnatomyEntry[]; metadata: { files: number; hits: number; misses: number } } {
   const entries: AnatomyEntry[] = [];
   let currentSection = "";

--- a/tests/buglog-shape.test.ts
+++ b/tests/buglog-shape.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 
 import { readBugLogFile } from "../src/hooks/shared.ts";
 import { buildHookSettings, HOOK_COUNT } from "../src/cli/hook-manifest.ts";
+import { parseCronState } from "../src/dashboard/app/lib/file-parsers.ts";
 
 // bug-tracker.ts imports ../utils/fs-safe.js, and node's type stripping does
 // not map a .js specifier onto its .ts source, so the CLI side is exercised
@@ -70,6 +71,28 @@ describe("buglog shape coercion", () => {
     assert.equal(tracker!.searchBugs(wolfDir, "widget").length, 1);
     assert.equal(tracker!.searchBugs(wolfDir, "nothing-matches-this").length, 0);
   });
+});
+
+test("dashboard coerces nullable cron-state collections before rendering", () => {
+  const nullable = parseCronState(JSON.stringify({
+    engine_status: "idle",
+    last_heartbeat: null,
+    execution_log: null,
+    dead_letter_queue: null,
+  }));
+  assert.deepEqual(nullable.execution_log, []);
+  assert.deepEqual(nullable.dead_letter_queue, []);
+
+  const missing = parseCronState("{}");
+  assert.deepEqual(missing.execution_log, []);
+  assert.deepEqual(missing.dead_letter_queue, []);
+  assert.throws(() => parseCronState("{"));
+
+  const executionLog = [{ task: "scan" }];
+  const deadLetterQueue = [{ task: "index" }];
+  const valid = parseCronState(JSON.stringify({ execution_log: executionLog, dead_letter_queue: deadLetterQueue }));
+  assert.deepEqual(valid.execution_log, executionLog);
+  assert.deepEqual(valid.dead_letter_queue, deadLetterQueue);
 });
 
 // Hook commands used to carry $CLAUDE_PROJECT_DIR / %CLAUDE_PROJECT_DIR%.


### PR DESCRIPTION
## What
Normalize persisted cron-state collections at the shared parser boundary and route dashboard updates through that parser. Add regression coverage for nullable, missing, valid, and malformed cron state.

## Why
Legacy or partial `.wolf/cron-state.json` files may contain `null` collections. Dashboard consumers require arrays, so those persisted values can throw during rendering and leave the page blank.

## How
- Preserve valid `execution_log` and `dead_letter_queue` arrays; coerce other shapes to empty arrays.
- Preserve malformed-JSON failure behavior handled by the existing caller.
- Validate with `npx pnpm@10 test`, `npx pnpm@10 build`, and `node dist/bin/openwolf.js --help`.