### PR TITLE
Fix per-project accounting when SessionStart is missed

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "prepublishOnly": "pnpm build",
+    "pretest": "tsc && tsc -p tsconfig.hooks.json",
     "test": "node --test tests/*.test.ts"
   },
   "dependencies": {

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -27,10 +27,12 @@ function buildCodexHooks(projectRoot: string) {
       ],
       PreToolUse: [
         { matcher: "Read", hooks: [hookEntry(projectRoot, "pre-read.js", 5, "OpenWolf read precheck")] },
+        { matcher: "Bash", hooks: [hookEntry(projectRoot, "pre-bash.js", 5, "OpenWolf Bash precheck")] },
         { matcher: "Edit|Write|MultiEdit|apply_patch", hooks: [hookEntry(projectRoot, "pre-write.js", 5, "OpenWolf write precheck")] },
       ],
       PostToolUse: [
         { matcher: "Read", hooks: [hookEntry(projectRoot, "post-read.js", 5, "OpenWolf read tracking")] },
+        { matcher: "Bash", hooks: [hookEntry(projectRoot, "post-bash.js", 10, "OpenWolf Bash tracking")] },
         { matcher: "Edit|Write|MultiEdit|apply_patch", hooks: [hookEntry(projectRoot, "post-write.js", 10, "OpenWolf anatomy update")] },
       ],
       PreCompact: [

--- a/src/hooks/post-bash.ts
+++ b/src/hooks/post-bash.ts
@@ -54,7 +54,7 @@ async function main(): Promise<void> {
   const raw = await readStdin();
   let input: {
     tool_input?: { command?: string };
-    tool_response?: { stdout?: string; stderr?: string; [key: string]: unknown };
+    tool_response?: string | { stdout?: string; stderr?: string; [key: string]: unknown };
     tool_use_id?: string;
     session_id?: string;
   };
@@ -66,7 +66,7 @@ async function main(): Promise<void> {
 
   const command = input.tool_input?.command ?? "";
   const resp = input.tool_response;
-  const stdout = typeof resp?.stdout === "string" ? resp.stdout : "";
+  const stdout = typeof resp === "string" ? resp : typeof resp?.stdout === "string" ? resp.stdout : "";
   if (!command || !resp) return;
 
   const sessionFile = getSessionFilePath(input);
@@ -152,10 +152,10 @@ async function main(): Promise<void> {
         } catch {}
 
         if (effectiveAction === "replace") {
-          // Mirror the received object exactly; change ONLY stdout. A shape
-          // mismatch makes the harness silently ignore the replacement.
+          // Preserve the received response shape. A mismatch makes the
+          // harness silently ignore the replacement.
           emitHookJSON("PostToolUse", {
-            updatedToolOutput: { ...resp, stdout: result.text },
+            updatedToolOutput: typeof resp === "string" ? result.text : { ...resp, stdout: result.text },
             additionalContext: notes.length > 0 ? notes.join("\n") : undefined,
           });
           return;

--- a/src/hooks/post-bash.ts
+++ b/src/hooks/post-bash.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import * as crypto from "node:crypto";
 import {
   getWolfDir, ensureWolfDir, readJSON, writeJSON, readStdin, emitHookJSON,
-  hookMain, getProjectDir, getSessionFilePath, normalizePath, readSessionState
+  hookMain, getSessionFilePath, normalizePath, readSessionState
 } from "./shared.js";
 import {
   classifyCommand, condenseOutput, estimateTokens,
@@ -76,7 +76,7 @@ async function main(): Promise<void> {
   try {
     const read = parseBashRead(command);
     if (read && stdout.length > 0) {
-      const normalized = normalizePath(path.isAbsolute(read.file) ? read.file : path.join(getProjectDir(), read.file));
+      const normalized = normalizePath(path.isAbsolute(read.file) ? read.file : path.resolve(process.cwd(), read.file));
       if (!normalized.includes("/.wolf/")) {
         const session = readSessionState(sessionFile, input.session_id) as {
           files_read?: Record<string, { count: number; tokens: number; first_read: string; ranged?: boolean; read_mtime?: number; via_bash?: boolean }>;
@@ -146,7 +146,7 @@ async function main(): Promise<void> {
           at: new Date().toISOString(),
         };
         try {
-          const session = readJSON<{ bash_governed?: GovernedRecord[] }>(sessionFile, {});
+          const session = readSessionState(sessionFile, input.session_id) as { bash_governed?: GovernedRecord[] };
           session.bash_governed = [...(session.bash_governed ?? []), record].slice(-200);
           writeJSON(sessionFile, session);
         } catch {}

--- a/src/hooks/post-bash.ts
+++ b/src/hooks/post-bash.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import * as crypto from "node:crypto";
 import {
   getWolfDir, ensureWolfDir, readJSON, writeJSON, readStdin, emitHookJSON,
-  hookMain, getSessionFilePath, normalizePath
+  hookMain, getProjectDir, getSessionFilePath, normalizePath, readSessionState
 } from "./shared.js";
 import {
   classifyCommand, condenseOutput, estimateTokens,
@@ -76,9 +76,11 @@ async function main(): Promise<void> {
   try {
     const read = parseBashRead(command);
     if (read && stdout.length > 0) {
-      const normalized = normalizePath(path.isAbsolute(read.file) ? read.file : path.join(process.env.CLAUDE_PROJECT_DIR ?? process.cwd(), read.file));
+      const normalized = normalizePath(path.isAbsolute(read.file) ? read.file : path.join(getProjectDir(), read.file));
       if (!normalized.includes("/.wolf/")) {
-        const session = readJSON<{ files_read?: Record<string, { count: number; tokens: number; first_read: string; ranged?: boolean; read_mtime?: number; via_bash?: boolean }> }>(sessionFile, {});
+        const session = readSessionState(sessionFile, input.session_id) as {
+          files_read?: Record<string, { count: number; tokens: number; first_read: string; ranged?: boolean; read_mtime?: number; via_bash?: boolean }>;
+        };
         if (!session.files_read) session.files_read = {};
         const prev = session.files_read[normalized];
         let unchanged = false;

--- a/src/hooks/post-batch.ts
+++ b/src/hooks/post-batch.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
   getWolfDir, ensureWolfDir, readJSON, writeJSON, readStdin, emitHookJSON,
-  hookMain, getSessionFilePath, recordInjection
+  hookMain, getSessionFilePath, recordInjection, readSessionState
 } from "./shared.js";
 import { topRules } from "./rule-reinjection.js";
 
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
   const interval = reinjectionInterval(wolfDir);
   if (interval === 0) return;
 
-  const session = readJSON<{ tool_batches?: number; [k: string]: unknown }>(sessionFile, {});
+  const session = readSessionState(sessionFile, input.session_id) as { tool_batches?: number; [k: string]: unknown };
   session.tool_batches = ((session.tool_batches as number) ?? 0) + 1;
 
   if (session.tool_batches % interval !== 0) {

--- a/src/hooks/post-read.ts
+++ b/src/hooks/post-read.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { getWolfDir, ensureWolfDir, readJSON, writeJSON, estimateTokens, readStdin, normalizePath, getProjectDir, hookMain, getSessionFilePath } from "./shared.js";
+import { getWolfDir, ensureWolfDir, writeJSON, estimateTokens, readStdin, normalizePath, getProjectDir, hookMain, getSessionFilePath, readSessionState } from "./shared.js";
 import { lookupEntry } from "./anatomy-store.js";
 
 interface SessionData {
@@ -71,7 +71,7 @@ async function main(): Promise<void> {
     // separately from project reads so anatomy hit-rates stay meaningful.
     try {
       if (content) {
-        const session = readJSON<SessionData>(sessionFile, { files_read: {} });
+        const session = readSessionState(sessionFile, input.session_id) as SessionData;
         const tok = estimateTokens(content, "prose");
         session.wolf_internal_tokens = ((session.wolf_internal_tokens as number) ?? 0) + tok;
         const perFile = (session.wolf_internal_reads ?? {}) as Record<string, number>;
@@ -96,7 +96,7 @@ async function main(): Promise<void> {
     if (entry) tokens = entry.tokens;
   }
 
-  const session = readJSON<SessionData>(sessionFile, { files_read: {} });
+  const session = readSessionState(sessionFile, input.session_id) as SessionData;
   const existing = session.files_read[normalizedFile];
   if (existing && existing.ranged !== true) {
     existing.tokens = tokens;

--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -4,7 +4,8 @@ import * as crypto from "node:crypto";
 import {
   getWolfDir, ensureWolfDir, readJSON, writeJSON, readBugLogFile, readMarkdown,
   extractDescription, estimateTokens, appendMarkdown, timeShort, readStdin, normalizePath,
-  isSensitiveFile, getProjectDir, emitHookJSON, recordInjection, hookMain, getSessionFilePath
+  isSensitiveFile, getProjectDir, emitHookJSON, recordInjection, hookMain, getSessionFilePath,
+  readSessionState
 } from "./shared.js";
 import { loadStoreReconciled, saveStore, renderToFile, sha256 } from "./anatomy-store.js";
 import { withAnatomyLock, HOOK_LOCK_BUDGET_MS } from "./anatomy-lock.js";
@@ -79,7 +80,7 @@ async function main(): Promise<void> {
         const content = fs.readFileSync(absolutePath, "utf-8");
         const tokens = estimateTokens(content, "prose");
         if (tokens > budget) {
-          const session = readJSON<SessionData>(sessionFile, { files_written: [], edit_counts: {} });
+          const session = readSessionState(sessionFile, input.session_id) as SessionData;
           const warned = (session.budget_warned ?? {}) as Record<string, boolean>;
           if (!warned[relPath]) {
             warned[relPath] = true;
@@ -183,7 +184,7 @@ async function main(): Promise<void> {
 
   // 3. Record in session tracker + track edit counts
   try {
-    const session = readJSON<SessionData>(sessionFile, { files_written: [], edit_counts: {} });
+    const session = readSessionState(sessionFile, input.session_id) as SessionData;
     if (!session.edit_counts) session.edit_counts = {};
 
     const normalizedFile = normalizePath(filePath);

--- a/src/hooks/pre-bash.ts
+++ b/src/hooks/pre-bash.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { getWolfDir, ensureWolfDir, readJSON, writeJSON, readStdin, emitHookJSON, recordInjection, hookMain, getSessionFilePath } from "./shared.js";
+import { getWolfDir, ensureWolfDir, readJSON, writeJSON, readStdin, emitHookJSON, recordInjection, hookMain, getSessionFilePath, readSessionState } from "./shared.js";
 import { shouldSuggestFilter } from "./bash-filter.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
   // Once per session per command family: nagging every test run costs more
   // context than it saves.
   const family = command.trim().split(/\s+/).slice(0, 2).join(" ");
-  const session = readJSON<{ bash_filter_suggested?: Record<string, boolean>; [k: string]: unknown }>(sessionFile, {});
+  const session = readSessionState(sessionFile, input.session_id) as { bash_filter_suggested?: Record<string, boolean>; [k: string]: unknown };
   if (session.bash_filter_suggested?.[family]) { return; }
 
   const note =

--- a/src/hooks/pre-read.ts
+++ b/src/hooks/pre-read.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import {
   getWolfDir, ensureWolfDir, readJSON, writeJSON,
   estimateTokens, readStdin, normalizePath, getProjectDir, emitHookJSON, recordInjection,
-  hookMain, getSessionFilePath
+  hookMain, getSessionFilePath, readSessionState
 } from "./shared.js";
 import { lookupEntry } from "./anatomy-store.js";
 
@@ -102,9 +102,7 @@ async function main(): Promise<void> {
         let sizeTokens = 0;
         try { sizeTokens = Math.ceil(fs.statSync(filePath).size / 3.5); } catch {}
         if (sizeTokens > 1500) {
-          const session = readJSON<SessionData>(sessionFile, {
-            session_id: "", files_read: {}, anatomy_hits: 0, anatomy_misses: 0, repeated_reads_warned: 0,
-          });
+          const session = readSessionState(sessionFile, input.session_id) as SessionData;
           const warned = (session.wolf_read_advised ?? {}) as Record<string, boolean>;
           if (!warned[base]) {
             warned[base] = true;
@@ -122,10 +120,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const session = readJSON<SessionData>(sessionFile, {
-    session_id: "", files_read: {}, anatomy_hits: 0, anatomy_misses: 0,
-    repeated_reads_warned: 0,
-  });
+  const session = readSessionState(sessionFile, input.session_id) as SessionData;
 
   if (isRangedRead) {
     // Record the contact so dedupe knows about it, but flagged: a ranged

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { getWolfDir, ensureWolfDir, readJSON, appendMarkdown, timeShort, readStdin, hookMain, getSessionFilePath } from "./shared.js";
+import { getWolfDir, ensureWolfDir, writeJSON, appendMarkdown, timeShort, readStdin, hookMain, getSessionFilePath, readSessionState } from "./shared.js";
 import { buildSessionEntry, flushSessionToLedger, type SessionData } from "./ledger.js";
 import { verifyHookDelivery } from "./hook-attachments.js";
 
@@ -19,14 +19,15 @@ async function main(): Promise<void> {
   } catch {}
   const sessionFile = getSessionFilePath(hookInput);
 
-  const session = readJSON<SessionData | null>(sessionFile, null);
-  if (!session || !session.session_id) {
+  const session = readSessionState(sessionFile, hookInput.session_id);
+  if (!session.session_id) {
     return;
   }
 
   const readCount = Object.keys(session.files_read ?? {}).length;
   const writeCount = (session.files_written ?? []).length;
   if (readCount === 0 && writeCount === 0) {
+    writeJSON(sessionFile, session);
     return;
   }
 
@@ -36,6 +37,7 @@ async function main(): Promise<void> {
     if (verified) entry.verified = verified;
   }
   flushSessionToLedger(wolfDir, entry);
+  writeJSON(sessionFile, session);
 
   if (writeCount > 0) {
     try {

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getWolfDir, ensureWolfDir, writeJSON, appendMarkdown, readJSON, readBugLogFile, timestamp, timeShort, estimateTokens, readStdin, detectAgent, recordInjectionToSessionFile, getProjectDir, hookMain, getSessionFilePath, gcSessionFiles } from "./shared.js";
+import { getWolfDir, ensureWolfDir, writeJSON, appendMarkdown, readJSON, readBugLogFile, timestamp, timeShort, estimateTokens, readStdin, detectAgent, recordInjectionToSessionFile, getProjectDir, hookMain, getSessionFilePath, gcSessionFiles, readSessionState } from "./shared.js";
 import { loadStore } from "./anatomy-store.js";
 import { topRules, scopedRulesForFiles } from "./rule-reinjection.js";
 
@@ -210,7 +210,7 @@ async function main(): Promise<void> {
   // recorded read (the warn path still fires; only denial is disarmed).
   if (continuing && source === "compact") {
     try {
-      const session = readJSON<{ files_read?: Record<string, { compacted?: boolean }> }>(sessionFile, {});
+      const session = readSessionState(sessionFile, hookInput.session_id) as { files_read?: Record<string, { compacted?: boolean }> };
       if (session.files_read) {
         for (const entry of Object.values(session.files_read)) {
           entry.compacted = true;
@@ -308,7 +308,7 @@ async function main(): Promise<void> {
     // scoped rules for files this session already touched, plus the top
     // Do-Not-Repeat rules (decay countermeasure) and the in-flight state.
     if (continuing && source === "compact") {
-      const session = readJSON<{ files_written?: Array<{ file: string }>; files_read?: Record<string, unknown>; edit_counts?: Record<string, number> }>(sessionFile, {});
+      const session = readSessionState(sessionFile, hookInput.session_id) as { files_written?: Array<{ file: string }>; files_read?: Record<string, unknown>; edit_counts?: Record<string, number> };
       const restoreParts: string[] = [];
 
       const files = [...new Set((session.files_written ?? []).map((w) => w.file))];

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -8,12 +8,24 @@ import type { SessionData } from "./ledger-math.js";
 // during a session. Each supported agent exposes its own env var; hooks are
 // provider-agnostic (Workstream C) so all are checked.
 //
-// None of those vars are guaranteed. Claude Code in particular does not put
-// CLAUDE_PROJECT_DIR in the hook process's environment on any platform: it
-// delivers project context through the stdin JSON payload instead. So before
-// falling back to CWD, derive the root from this script's own location. A hook
-// always runs as <project>/.wolf/hooks/<name>.js, which makes the project root
-// two directories up, verified by the .wolf/ directory being there.
+// None of those vars are guaranteed. Codex runs command hooks from the active
+// request cwd, so its nearest .wolf ancestor must win over a copied script's
+// installation root. Script location and legacy provider vars remain fallbacks.
+function projectDirFromCwd(): string | null {
+  try {
+    let current = fs.realpathSync.native(process.cwd());
+    while (true) {
+      const wolfDir = path.join(current, ".wolf");
+      if (fs.existsSync(wolfDir) && fs.statSync(wolfDir).isDirectory()) return current;
+      const parent = path.dirname(current);
+      if (parent === current) return null;
+      current = parent;
+    }
+  } catch {
+    return null;
+  }
+}
+
 function projectDirFromScriptLocation(): string | null {
   try {
     const here = path.dirname(fileURLToPath(import.meta.url));
@@ -29,9 +41,10 @@ function projectDirFromScriptLocation(): string | null {
 export function getProjectDir(): string {
   return (
     process.env.CLAUDE_PROJECT_DIR ||
+    projectDirFromCwd() ||
+    projectDirFromScriptLocation() ||
     process.env.CODEX_PROJECT_ROOT ||
     process.env.OPENWOLF_PROJECT_ROOT ||
-    projectDirFromScriptLocation() ||
     process.cwd()
   );
 }

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
 import { fileURLToPath } from "node:url";
+import type { SessionData } from "./ledger-math.js";
 
 // Prefer the harness-provided project dir so hooks work even if CWD changes
 // during a session. Each supported agent exposes its own env var; hooks are
@@ -133,6 +134,24 @@ export function getSessionFilePath(hookInput: { session_id?: string } | undefine
   }
   // Legacy fallback for agents that pass no session id.
   return path.join(hooksDir, "_session.json");
+}
+
+/** Restore the complete SessionStart shape when a later hook arrives first. */
+export function readSessionState(sessionFile: string, sessionId?: string): SessionData {
+  const existing = readJSON<Partial<SessionData>>(sessionFile, {});
+  return {
+    session_id: sessionId ?? "",
+    started: new Date().toISOString(),
+    files_read: {},
+    files_written: [],
+    edit_counts: {},
+    anatomy_hits: 0,
+    anatomy_misses: 0,
+    repeated_reads_warned: 0,
+    stop_count: 0,
+    reminders_sent: {},
+    ...existing,
+  };
 }
 
 /** Delete session state files older than maxAgeDays (called from session-start). */

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -152,8 +152,16 @@ export function getSessionFilePath(hookInput: { session_id?: string } | undefine
 /** Restore the complete SessionStart shape when a later hook arrives first. */
 export function readSessionState(sessionFile: string, sessionId?: string): SessionData {
   const existing = readJSON<Partial<SessionData>>(sessionFile, {});
-  return {
-    session_id: sessionId ?? "",
+  const validSessionId = (value: unknown): value is string =>
+    typeof value === "string" && /^[\w.-]{4,128}$/.test(value);
+  const fileSessionId = path.basename(path.dirname(sessionFile)) === "sessions"
+    ? path.basename(sessionFile, ".json")
+    : "";
+  const authoritativeSessionId = validSessionId(sessionId)
+    ? sessionId
+    : validSessionId(fileSessionId) ? fileSessionId : "";
+  const session = {
+    session_id: authoritativeSessionId,
     started: new Date().toISOString(),
     files_read: {},
     files_written: [],
@@ -165,6 +173,39 @@ export function readSessionState(sessionFile: string, sessionId?: string): Sessi
     reminders_sent: {},
     ...existing,
   };
+  if (authoritativeSessionId) session.session_id = authoritativeSessionId;
+  else if (!validSessionId(session.session_id)) session.session_id = "";
+  if (typeof session.started !== "string" || !session.started) session.started = new Date().toISOString();
+  if (!session.files_read || typeof session.files_read !== "object" || Array.isArray(session.files_read)) session.files_read = {};
+  if (!Array.isArray(session.files_written)) session.files_written = [];
+  session.files_read = Object.fromEntries(Object.entries(session.files_read).map(([file, value]) => {
+    const read = value && typeof value === "object" ? value as unknown as Record<string, unknown> : {};
+    return [file, {
+      ...read,
+      count: typeof read.count === "number" && Number.isFinite(read.count) && read.count >= 1 ? Math.floor(read.count) : 1,
+      tokens: typeof read.tokens === "number" && Number.isFinite(read.tokens) && read.tokens >= 0 ? read.tokens : 0,
+      first_read: typeof read.first_read === "string" && read.first_read ? read.first_read : session.started,
+    }];
+  })) as SessionData["files_read"];
+  session.files_written = session.files_written.flatMap((value) => {
+    if (!value || typeof value !== "object") return [];
+    const write = value as unknown as Record<string, unknown>;
+    if (typeof write.file !== "string" || !write.file) return [];
+    return [{
+      ...write,
+      file: write.file,
+      action: typeof write.action === "string" && write.action ? write.action : "write",
+      tokens: typeof write.tokens === "number" && Number.isFinite(write.tokens) && write.tokens >= 0 ? write.tokens : 0,
+      at: typeof write.at === "string" && write.at ? write.at : session.started,
+    }];
+  }) as SessionData["files_written"];
+  if (!session.edit_counts || typeof session.edit_counts !== "object" || Array.isArray(session.edit_counts)) session.edit_counts = {};
+  if (typeof session.anatomy_hits !== "number" || !Number.isFinite(session.anatomy_hits)) session.anatomy_hits = 0;
+  if (typeof session.anatomy_misses !== "number" || !Number.isFinite(session.anatomy_misses)) session.anatomy_misses = 0;
+  if (typeof session.repeated_reads_warned !== "number" || !Number.isFinite(session.repeated_reads_warned)) session.repeated_reads_warned = 0;
+  if (typeof session.stop_count !== "number" || !Number.isFinite(session.stop_count)) session.stop_count = 0;
+  if (!session.reminders_sent || typeof session.reminders_sent !== "object" || Array.isArray(session.reminders_sent)) session.reminders_sent = {};
+  return session;
 }
 
 /** Delete session state files older than maxAgeDays (called from session-start). */
@@ -798,7 +839,7 @@ export function recordInjection(session: InjectionTracking, source: string, text
 export function recordInjectionToSessionFile(sessionFile: string, source: string, text: string): void {
   if (!text) return;
   try {
-    const session = readJSON<InjectionTracking>(sessionFile, {});
+    const session = readSessionState(sessionFile) as InjectionTracking;
     recordInjection(session, source, text);
     writeJSON(sessionFile, session);
   } catch {}

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getWolfDir, ensureWolfDir, readJSON, writeJSON, countSemanticEntries, readStdin, hookMain, getSessionFilePath } from "./shared.js";
+import { getWolfDir, ensureWolfDir, writeJSON, countSemanticEntries, readStdin, hookMain, getSessionFilePath, readSessionState } from "./shared.js";
 import { buildSessionEntry, flushSessionToLedger, type SessionData } from "./ledger.js";
 import { verifyHookDelivery } from "./hook-attachments.js";
 
@@ -15,18 +15,7 @@ async function main(): Promise<void> {
   } catch {}
   const sessionFile = getSessionFilePath(hookInput);
 
-  const session = readJSON<SessionData>(sessionFile, {
-    session_id: "",
-    started: "",
-    files_read: {},
-    files_written: [],
-    edit_counts: {},
-    anatomy_hits: 0,
-    anatomy_misses: 0,
-    repeated_reads_warned: 0,
-    stop_count: 0,
-    reminders_sent: {},
-  });
+  const session = readSessionState(sessionFile, hookInput.session_id);
 
   session.stop_count++;
 

--- a/src/hooks/user-prompt-submit.ts
+++ b/src/hooks/user-prompt-submit.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { ensureWolfDir, readJSON, writeJSON, emitHookJSON, recordInjection, readStdin, hookMain, getSessionFilePath } from "./shared.js";
+import { ensureWolfDir, writeJSON, emitHookJSON, recordInjection, readStdin, hookMain, getSessionFilePath, readSessionState } from "./shared.js";
 
 // UserPromptSubmit hook: drains reminders the Stop hook queued last turn.
 //
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
     input = JSON.parse(await readStdin());
   } catch {}
   const sessionFile = getSessionFilePath(input);
-  const session = readJSON<SessionData>(sessionFile, {});
+  const session = readSessionState(sessionFile, input.session_id) as SessionData;
   const pending = session.pending_reminders ?? [];
   if (pending.length === 0) {
     return;

--- a/tests/hook-health.test.ts
+++ b/tests/hook-health.test.ts
@@ -139,4 +139,76 @@ describe("compiled hook integration", { skip: !haveDist ? "dist/hooks not built"
     assert.ok(fs.existsSync(path.join(hooksDir, "sessions", "sessA.json")));
     assert.ok(fs.existsSync(path.join(hooksDir, "sessions", "sessB.json")));
   });
+
+  test("accounts for Claude and Codex activity when SessionStart was missed", async () => {
+    const installedRoot = tmpProject();
+    const { resolveAgents } = await import("../dist/src/agents/index.js");
+    const codexAdapter = resolveAgents(["codex"])[0];
+    codexAdapter.install({
+      projectRoot: installedRoot,
+      wolfDir: path.join(installedRoot, ".wolf"),
+      templatesDir: path.resolve("src", "templates"),
+    });
+    const installedHooks = JSON.parse(fs.readFileSync(path.join(installedRoot, ".codex", "hooks.json"), "utf-8"));
+    assert.ok(installedHooks.hooks.PreToolUse.some((entry: { matcher: string; hooks: Array<{ command: string }> }) => entry.matcher === "Bash" && entry.hooks[0].command.endsWith("pre-bash.js\"")));
+    assert.ok(installedHooks.hooks.PostToolUse.some((entry: { matcher: string; hooks: Array<{ command: string }> }) => entry.matcher === "Bash" && entry.hooks[0].command.endsWith("post-bash.js\"")));
+
+    const exercise = async (runtime: "claude" | "codex") => {
+      const root = tmpProject();
+      const decoyRoot = tmpProject();
+      const hooksDir = path.join(root, ".wolf", "hooks");
+      fs.cpSync(DIST_HOOKS, hooksDir, { recursive: true });
+      fs.writeFileSync(path.join(hooksDir, "package.json"), JSON.stringify({ type: "module" }));
+
+      const readTarget = path.join(root, "read.ts");
+      const writeTarget = path.join(root, "write.ts");
+      fs.writeFileSync(readTarget, "export const read = 1;\n");
+      fs.writeFileSync(writeTarget, "export const write = 1;\n");
+
+      const sessionId = `${runtime}-missed-start`;
+      const runHook = (file: string, payload: unknown): Promise<void> =>
+        new Promise((resolve, reject) => {
+          const env = { ...process.env };
+          delete env.CLAUDE_PROJECT_DIR;
+          delete env.CODEX_PROJECT_ROOT;
+          delete env.OPENWOLF_PROJECT_ROOT;
+          env[runtime === "claude" ? "CLAUDE_PROJECT_DIR" : "CODEX_PROJECT_ROOT"] = root;
+
+          const child = execFile(
+            process.execPath,
+            [path.join(hooksDir, file)],
+            { env, timeout: 10000 },
+            (err) => (err ? reject(err) : resolve())
+          );
+          child.stdin!.end(JSON.stringify(payload));
+        });
+
+      await runHook(runtime === "claude" ? "post-read.js" : "post-bash.js", {
+        session_id: sessionId,
+        tool_name: runtime === "claude" ? "Read" : "Bash",
+        tool_input: runtime === "claude" ? { file_path: readTarget } : { command: `cat ${readTarget}` },
+        tool_response: runtime === "claude" ? { file: { content: "export const read = 1;\n" } } : { stdout: "export const read = 1;\n" },
+      });
+      if (runtime === "codex") {
+        const recovered = JSON.parse(fs.readFileSync(path.join(hooksDir, "sessions", `${sessionId}.json`), "utf-8"));
+        assert.strictEqual(recovered.session_id, sessionId, "Bash recovery keeps the session ID before the write hook");
+      }
+      await runHook("post-write.js", {
+        session_id: sessionId,
+        tool_name: runtime === "claude" ? "Edit" : "apply_patch",
+        tool_input: { file_path: writeTarget, old_string: "1", new_string: "2" },
+      });
+      await runHook("stop.js", { session_id: sessionId });
+
+      const ledgerPath = path.join(root, ".wolf", "token-ledger.json");
+      assert.ok(fs.existsSync(ledgerPath), `${runtime} Stop must persist the ledger`);
+      const ledger = JSON.parse(fs.readFileSync(ledgerPath, "utf-8"));
+      assert.strictEqual(ledger.lifetime.total_reads, 1, `${runtime} read accounting`);
+      assert.strictEqual(ledger.lifetime.total_writes, 1, `${runtime} write accounting`);
+      assert.ok(!fs.existsSync(path.join(decoyRoot, ".wolf", "token-ledger.json")), `${runtime} must not create a decoy ledger`);
+    };
+
+    await exercise("claude");
+    await exercise("codex");
+  });
 });

--- a/tests/hook-health.test.ts
+++ b/tests/hook-health.test.ts
@@ -156,9 +156,11 @@ describe("compiled hook integration", { skip: !haveDist ? "dist/hooks not built"
     const exercise = async (runtime: "claude" | "codex") => {
       const root = tmpProject();
       const decoyRoot = tmpProject();
-      const hooksDir = path.join(root, ".wolf", "hooks");
+      const hooksDir = path.join(runtime === "codex" ? decoyRoot : root, ".wolf", "hooks");
       fs.cpSync(DIST_HOOKS, hooksDir, { recursive: true });
       fs.writeFileSync(path.join(hooksDir, "package.json"), JSON.stringify({ type: "module" }));
+      const nestedCwd = path.join(root, "nested", "work");
+      fs.mkdirSync(nestedCwd, { recursive: true });
 
       const readTarget = path.join(root, "read.ts");
       const writeTarget = path.join(root, "write.ts");
@@ -166,45 +168,86 @@ describe("compiled hook integration", { skip: !haveDist ? "dist/hooks not built"
       fs.writeFileSync(writeTarget, "export const write = 1;\n");
 
       const sessionId = `${runtime}-missed-start`;
-      const runHook = (file: string, payload: unknown): Promise<void> =>
+      const runHook = (file: string, payload: unknown, cwd = root): Promise<{ stdout: string }> =>
         new Promise((resolve, reject) => {
           const env = { ...process.env };
           delete env.CLAUDE_PROJECT_DIR;
           delete env.CODEX_PROJECT_ROOT;
           delete env.OPENWOLF_PROJECT_ROOT;
-          env[runtime === "claude" ? "CLAUDE_PROJECT_DIR" : "CODEX_PROJECT_ROOT"] = root;
+          if (runtime === "claude") env.CLAUDE_PROJECT_DIR = root;
 
           const child = execFile(
             process.execPath,
             [path.join(hooksDir, file)],
-            { env, timeout: 10000 },
-            (err) => (err ? reject(err) : resolve())
+            { cwd, env, timeout: 10000 },
+            (err, stdout) => (err ? reject(err) : resolve({ stdout }))
           );
           child.stdin!.end(JSON.stringify(payload));
         });
 
-      await runHook(runtime === "claude" ? "post-read.js" : "post-bash.js", {
-        session_id: sessionId,
-        tool_name: runtime === "claude" ? "Read" : "Bash",
-        tool_input: runtime === "claude" ? { file_path: readTarget } : { command: `cat ${readTarget}` },
-        tool_response: runtime === "claude" ? { file: { content: "export const read = 1;\n" } } : { stdout: "export const read = 1;\n" },
-      });
+      if (runtime === "claude") {
+        await runHook("post-read.js", {
+          session_id: sessionId,
+          tool_name: "Read",
+          tool_input: { file_path: readTarget },
+          tool_response: { file: { content: "export const read = 1;\n" } },
+        });
+      } else {
+        const largeOutput = Array.from({ length: 240 }, (_, i) => `line ${i} ${"x".repeat(40)}`).join("\n");
+        const stringRun = await runHook("post-bash.js", {
+          session_id: sessionId,
+          tool_name: "Bash",
+          tool_input: { command: `cat ${readTarget}` },
+          tool_response: largeOutput,
+        }, nestedCwd);
+        assert.notStrictEqual(stringRun.stdout, "", "official string response must produce hook output");
+        const stringHookOutput = JSON.parse(stringRun.stdout);
+        assert.strictEqual(typeof stringHookOutput.hookSpecificOutput.updatedToolOutput, "string");
+
+        const objectResponse = {
+          stdout: Array.from({ length: 240 }, (_, i) => `diff line ${i} ${"y".repeat(40)}`).join("\n"),
+          stderr: "sentinel stderr\n",
+          exit_code: 17,
+          metadata: { sentinel: "preserve-byte-for-byte" },
+        };
+        const objectRun = await runHook("post-bash.js", {
+          session_id: sessionId,
+          tool_name: "Bash",
+          tool_input: { command: "git show HEAD" },
+          tool_response: objectResponse,
+        }, nestedCwd);
+        assert.notStrictEqual(objectRun.stdout, "", "object response must produce hook output");
+        const objectReplacement = JSON.parse(objectRun.stdout).hookSpecificOutput.updatedToolOutput;
+        assert.strictEqual(typeof objectReplacement, "object");
+        assert.notStrictEqual(objectReplacement.stdout, objectResponse.stdout);
+        assert.deepStrictEqual({ ...objectReplacement, stdout: objectResponse.stdout }, objectResponse);
+      }
       if (runtime === "codex") {
-        const recovered = JSON.parse(fs.readFileSync(path.join(hooksDir, "sessions", `${sessionId}.json`), "utf-8"));
+        const recoveredPath = path.join(root, ".wolf", "hooks", "sessions", `${sessionId}.json`);
+        assert.ok(fs.existsSync(recoveredPath), "Codex session must exist under the active cwd root");
+        const recovered = JSON.parse(fs.readFileSync(recoveredPath, "utf-8"));
         assert.strictEqual(recovered.session_id, sessionId, "Bash recovery keeps the session ID before the write hook");
       }
       await runHook("post-write.js", {
         session_id: sessionId,
         tool_name: runtime === "claude" ? "Edit" : "apply_patch",
         tool_input: { file_path: writeTarget, old_string: "1", new_string: "2" },
-      });
-      await runHook("stop.js", { session_id: sessionId });
+      }, runtime === "codex" ? nestedCwd : root);
+
+      const sessionPath = path.join(root, ".wolf", "hooks", "sessions", `${sessionId}.json`);
+      const session = JSON.parse(fs.readFileSync(sessionPath, "utf-8"));
+      assert.strictEqual(Object.keys(session.files_read).length, 1, `${runtime} unique read accounting`);
+      assert.strictEqual(Object.values(session.files_read)[0].count, 1, `${runtime} read count`);
+      assert.strictEqual(session.files_written.length, 1, `${runtime} unique write accounting`);
+
+      await runHook("stop.js", { session_id: sessionId }, runtime === "codex" ? nestedCwd : root);
 
       const ledgerPath = path.join(root, ".wolf", "token-ledger.json");
       assert.ok(fs.existsSync(ledgerPath), `${runtime} Stop must persist the ledger`);
       const ledger = JSON.parse(fs.readFileSync(ledgerPath, "utf-8"));
       assert.strictEqual(ledger.lifetime.total_reads, 1, `${runtime} read accounting`);
       assert.strictEqual(ledger.lifetime.total_writes, 1, `${runtime} write accounting`);
+      assert.ok(!fs.existsSync(path.join(decoyRoot, ".wolf", "hooks", "sessions", `${sessionId}.json`)), `${runtime} must not create a decoy session`);
       assert.ok(!fs.existsSync(path.join(decoyRoot, ".wolf", "token-ledger.json")), `${runtime} must not create a decoy ledger`);
     };
 

--- a/tests/hook-health.test.ts
+++ b/tests/hook-health.test.ts
@@ -8,7 +8,6 @@ import { execFileSync, execFile } from "node:child_process";
 import { recordHeartbeat, getSessionFilePath, gcSessionFiles } from "../src/hooks/shared.ts";
 
 const DIST_HOOKS = path.resolve(import.meta.dirname ?? ".", "..", "dist", "hooks");
-const haveDist = fs.existsSync(path.join(DIST_HOOKS, "pre-read.js"));
 
 function tmpProject(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "wolf-hh-"));
@@ -25,6 +24,62 @@ function withProjectEnv<T>(root: string, fn: () => T): T {
     if (prev === undefined) delete process.env.CLAUDE_PROJECT_DIR;
     else process.env.CLAUDE_PROJECT_DIR = prev;
   }
+}
+
+function installHooks(root: string): string {
+  const hooksDir = path.join(root, ".wolf", "hooks");
+  fs.cpSync(DIST_HOOKS, hooksDir, { recursive: true });
+  fs.writeFileSync(path.join(hooksDir, "package.json"), JSON.stringify({ type: "module" }));
+  return hooksDir;
+}
+
+function sessionPath(root: string, id: string): string {
+  return path.join(root, ".wolf", "hooks", "sessions", `${id}.json`);
+}
+
+function readSession(root: string, id: string): Record<string, any> {
+  return JSON.parse(fs.readFileSync(sessionPath(root, id), "utf-8"));
+}
+
+function assertCompleteSession(root: string, id: string, message: string): Record<string, any> {
+  const session = readSession(root, id);
+  assert.strictEqual(session.session_id, id, `${message}: session_id`);
+  assert.strictEqual(typeof session.started, "string", `${message}: started`);
+  assert.ok(session.started.length > 0, `${message}: started value`);
+  assert.ok(session.files_read && typeof session.files_read === "object" && !Array.isArray(session.files_read), `${message}: files_read`);
+  assert.ok(Array.isArray(session.files_written), `${message}: files_written`);
+  assert.ok(session.edit_counts && typeof session.edit_counts === "object" && !Array.isArray(session.edit_counts), `${message}: edit_counts`);
+  assert.strictEqual(typeof session.anatomy_hits, "number", `${message}: anatomy_hits`);
+  assert.strictEqual(typeof session.anatomy_misses, "number", `${message}: anatomy_misses`);
+  assert.strictEqual(typeof session.repeated_reads_warned, "number", `${message}: repeated_reads_warned`);
+  assert.strictEqual(typeof session.stop_count, "number", `${message}: stop_count`);
+  assert.ok(session.reminders_sent && typeof session.reminders_sent === "object" && !Array.isArray(session.reminders_sent), `${message}: reminders_sent`);
+  return session;
+}
+
+function runInstalledHook(
+  hooksDir: string,
+  file: string,
+  payload: unknown,
+  cwd: string,
+  envExtra: NodeJS.ProcessEnv = {}
+): Promise<{ stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env, ...envExtra };
+    delete env.CLAUDE_PROJECT_DIR;
+    delete env.OPENWOLF_PROJECT_ROOT;
+    const child = execFile(
+      process.execPath,
+      [path.join(hooksDir, file)],
+      { cwd, env, timeout: 10000 },
+      (err, stdout) => (err ? reject(err) : resolve({ stdout }))
+    );
+    child.stdin!.end(JSON.stringify(payload));
+  });
+}
+
+function largeOutput(prefix = "line"): string {
+  return Array.from({ length: 260 }, (_, i) => `${prefix} ${i} ${"x".repeat(60)}`).join("\n");
 }
 
 describe("heartbeat", () => {
@@ -81,7 +136,7 @@ describe("session keying", () => {
   });
 });
 
-describe("compiled hook integration", { skip: !haveDist ? "dist/hooks not built" : false }, () => {
+describe("compiled hook integration", () => {
   test("--selfcheck passes on a healthy install and fails on a broken one", () => {
     const root = tmpProject();
     const hooksDir = path.join(root, ".wolf", "hooks");
@@ -253,5 +308,235 @@ describe("compiled hook integration", { skip: !haveDist ? "dist/hooks not built"
 
     await exercise("claude");
     await exercise("codex");
+  });
+
+  test("governed Bash and ranged Read preserve complete session shape before Stop", async () => {
+    const root = tmpProject();
+    const decoyRoot = tmpProject();
+    const hooksDir = installHooks(decoyRoot);
+    const nestedCwd = path.join(root, "nested", "work");
+    fs.mkdirSync(nestedCwd, { recursive: true });
+    const readTarget = path.join(root, "read.ts");
+    fs.writeFileSync(readTarget, "export const read = 1;\n");
+    const sessionId = "shape-core";
+
+    await runInstalledHook(hooksDir, "post-bash.js", {
+      session_id: sessionId,
+      tool_name: "Bash",
+      tool_input: { command: "git show HEAD" },
+      tool_response: { stdout: largeOutput("diff"), stderr: "", exit_code: 0 },
+    }, nestedCwd, { CODEX_PROJECT_ROOT: decoyRoot });
+    assertCompleteSession(root, sessionId, "post-bash governed writer");
+
+    await runInstalledHook(hooksDir, "pre-read.js", {
+      session_id: sessionId,
+      tool_input: { file_path: readTarget, offset: 1, limit: 1 },
+    }, nestedCwd, { CODEX_PROJECT_ROOT: decoyRoot });
+    assertCompleteSession(root, sessionId, "pre-read ranged writer");
+
+    await runInstalledHook(hooksDir, "stop.js", { session_id: sessionId }, nestedCwd, { CODEX_PROJECT_ROOT: decoyRoot });
+    const session = assertCompleteSession(root, sessionId, "stop terminal reader");
+    assert.strictEqual(session.stop_count, 1);
+    const ledger = JSON.parse(fs.readFileSync(path.join(root, ".wolf", "token-ledger.json"), "utf-8"));
+    assert.strictEqual(ledger.lifetime.total_reads, 1);
+    assert.strictEqual(ledger.lifetime.total_writes, 0);
+    assert.ok(!fs.existsSync(sessionPath(decoyRoot, sessionId)), "legacy CODEX_PROJECT_ROOT must not receive session state");
+    assert.ok(!fs.existsSync(path.join(decoyRoot, ".wolf", "token-ledger.json")), "legacy CODEX_PROJECT_ROOT must not receive ledger state");
+  });
+
+  test("relative Bash reads resolve from the hook command cwd", async () => {
+    const root = tmpProject();
+    const decoyRoot = tmpProject();
+    const hooksDir = installHooks(decoyRoot);
+    const nestedCwd = path.join(root, "nested", "work");
+    fs.mkdirSync(nestedCwd, { recursive: true });
+    const readTarget = path.join(nestedCwd, "local.ts");
+    fs.writeFileSync(readTarget, "export const local = 1;\n");
+    const sessionId = "relative-bash-cwd";
+
+    await runInstalledHook(hooksDir, "post-bash.js", {
+      session_id: sessionId,
+      tool_name: "Bash",
+      tool_input: { command: "cat local.ts" },
+      tool_response: "export const local = 1;\n",
+    }, nestedCwd, { CODEX_PROJECT_ROOT: decoyRoot });
+
+    const session = assertCompleteSession(root, sessionId, "relative Bash cwd");
+    assert.deepStrictEqual(Object.keys(session.files_read), [readTarget]);
+    assert.ok(!fs.existsSync(sessionPath(decoyRoot, sessionId)));
+  });
+
+  test("stop normalizes legacy partial session state before ledger accounting", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const sessionId = "shape-stop-legacy";
+    const readTarget = path.join(root, "read.ts");
+    fs.mkdirSync(path.dirname(sessionPath(root, sessionId)), { recursive: true });
+    fs.writeFileSync(sessionPath(root, sessionId), JSON.stringify({
+      files_read: {
+        [readTarget]: { count: 1, tokens: 0, first_read: new Date().toISOString(), ranged: true },
+      },
+    }, null, 2));
+
+    await runInstalledHook(hooksDir, "stop.js", { session_id: sessionId }, root);
+    const session = assertCompleteSession(root, sessionId, "stop legacy partial reader");
+    assert.strictEqual(session.stop_count, 1);
+    const ledger = JSON.parse(fs.readFileSync(path.join(root, ".wolf", "token-ledger.json"), "utf-8"));
+    assert.strictEqual(ledger.lifetime.total_reads, 1);
+    assert.strictEqual(ledger.lifetime.total_writes, 0);
+  });
+
+  test("current hook session id overrides stale persisted identity", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const sessionId = "current-session";
+    const readTarget = path.join(root, "read.ts");
+    fs.mkdirSync(path.dirname(sessionPath(root, sessionId)), { recursive: true });
+    fs.writeFileSync(sessionPath(root, sessionId), JSON.stringify({
+      session_id: "stale-session",
+      files_read: {
+        [readTarget]: { count: 1, tokens: 0, first_read: new Date().toISOString() },
+      },
+    }, null, 2));
+
+    await runInstalledHook(hooksDir, "stop.js", { session_id: sessionId }, root);
+    const session = assertCompleteSession(root, sessionId, "authoritative hook session id");
+    assert.strictEqual(session.session_id, sessionId);
+    const ledger = JSON.parse(fs.readFileSync(path.join(root, ".wolf", "token-ledger.json"), "utf-8"));
+    assert.strictEqual(ledger.sessions.at(-1).id, sessionId);
+  });
+
+  test("malformed nested accounting records normalize to finite ledger values", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const sessionId = "malformed-records";
+    const readTarget = path.join(root, "read.ts");
+    const writeTarget = path.join(root, "write.ts");
+    fs.mkdirSync(path.dirname(sessionPath(root, sessionId)), { recursive: true });
+    fs.writeFileSync(sessionPath(root, sessionId), JSON.stringify({
+      session_id: sessionId,
+      files_read: { [readTarget]: {} },
+      files_written: [{}, { file: writeTarget }],
+    }, null, 2));
+
+    await runInstalledHook(hooksDir, "stop.js", { session_id: sessionId }, root);
+    const session = assertCompleteSession(root, sessionId, "malformed nested records");
+    assert.strictEqual(session.files_read[readTarget].count, 1);
+    assert.strictEqual(session.files_read[readTarget].tokens, 0);
+    assert.deepStrictEqual(session.files_written.map((entry: { file: string }) => entry.file), [writeTarget]);
+    assert.strictEqual(session.files_written[0].tokens, 0);
+    const ledger = JSON.parse(fs.readFileSync(path.join(root, ".wolf", "token-ledger.json"), "utf-8"));
+    const entry = ledger.sessions.at(-1);
+    assert.ok(Number.isFinite(entry.totals.input_tokens_estimated));
+    assert.ok(Number.isFinite(entry.totals.output_tokens_estimated));
+    assert.strictEqual(entry.writes.length, 1);
+    assert.strictEqual(entry.writes[0].file, writeTarget);
+  });
+
+  test("pre-read ranged preserves complete session shape immediately", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const readTarget = path.join(root, "read.ts");
+    fs.writeFileSync(readTarget, "export const read = 1;\n");
+    const sessionId = "shape-pre-read";
+
+    await runInstalledHook(hooksDir, "pre-read.js", {
+      session_id: sessionId,
+      tool_input: { file_path: readTarget, offset: 1, limit: 1 },
+    }, root);
+    const session = assertCompleteSession(root, sessionId, "pre-read ranged writer");
+    assert.strictEqual(session.files_read[readTarget].ranged, true);
+  });
+
+  test("pre-write injection preserves complete session shape immediately", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    fs.writeFileSync(path.join(root, ".wolf", "cerebrum.md"), "## Do-Not-Repeat\n- never use eval\n");
+    const sessionId = "shape-pre-write";
+
+    await runInstalledHook(hooksDir, "pre-write.js", {
+      session_id: sessionId,
+      tool_input: { file_path: path.join(root, "unsafe.ts"), content: "eval('x')\n" },
+    }, root);
+    const session = assertCompleteSession(root, sessionId, "pre-write injection writer");
+    assert.ok(session.injected_tokens_estimated > 0, "pre-write must account for injected warning text");
+  });
+
+  test("pre-bash filter preserves complete session shape immediately", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const sessionId = "shape-pre-bash";
+
+    await runInstalledHook(hooksDir, "pre-bash.js", {
+      session_id: sessionId,
+      tool_input: { command: "npm test" },
+    }, root);
+    const session = assertCompleteSession(root, sessionId, "pre-bash filter writer");
+    assert.ok(session.bash_filter_suggested?.["npm test"]);
+  });
+
+  test("post-batch preserves complete session shape immediately", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const sessionId = "shape-post-batch";
+
+    await runInstalledHook(hooksDir, "post-batch.js", { session_id: sessionId }, root);
+    const session = assertCompleteSession(root, sessionId, "post-batch writer");
+    assert.strictEqual(session.tool_batches, 1);
+  });
+
+  test("user-prompt-submit drains reminders while normalizing partial session shape", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const sessionId = "shape-user-prompt";
+    fs.mkdirSync(path.dirname(sessionPath(root, sessionId)), { recursive: true });
+    fs.writeFileSync(sessionPath(root, sessionId), JSON.stringify({ pending_reminders: ["remember this"] }, null, 2));
+
+    await runInstalledHook(hooksDir, "user-prompt-submit.js", { session_id: sessionId }, root);
+    const session = assertCompleteSession(root, sessionId, "user-prompt-submit writer");
+    assert.deepStrictEqual(session.pending_reminders, []);
+    assert.ok(session.injected_tokens_estimated > 0, "reminder delivery must be injection-accounted");
+  });
+
+  test("session-start compact continuation preserves complete session shape", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const readTarget = path.join(root, "read.ts");
+    fs.writeFileSync(readTarget, "export const read = 1;\n");
+    fs.writeFileSync(path.join(root, ".wolf", "buglog.json"), JSON.stringify({ version: 1, bugs: [{}] }));
+    fs.writeFileSync(path.join(root, ".wolf", "config.json"), JSON.stringify({
+      openwolf: { context: { session_digest_budget_tokens: 0 } },
+    }));
+    const sessionId = "shape-compact";
+    fs.mkdirSync(path.dirname(sessionPath(root, sessionId)), { recursive: true });
+    fs.writeFileSync(sessionPath(root, sessionId), JSON.stringify({
+      session_id: sessionId,
+      files_read: {
+        [readTarget]: { count: 1, tokens: 0, first_read: new Date().toISOString(), ranged: true },
+      },
+    }, null, 2));
+    await runInstalledHook(hooksDir, "session-start.js", { session_id: sessionId, source: "compact" }, root);
+    const session = assertCompleteSession(root, sessionId, "session-start compact writer");
+    assert.strictEqual(session.files_read[readTarget].compacted, true);
+  });
+
+  test("session-end consumes recovered partial state and writes the ledger", async () => {
+    const root = tmpProject();
+    const hooksDir = installHooks(root);
+    const readTarget = path.join(root, "read.ts");
+    fs.writeFileSync(readTarget, "export const read = 1;\n");
+    const sessionId = "shape-session-end";
+    fs.mkdirSync(path.dirname(sessionPath(root, sessionId)), { recursive: true });
+    fs.writeFileSync(sessionPath(root, sessionId), JSON.stringify({
+      session_id: sessionId,
+      files_read: {
+        [readTarget]: { count: 1, tokens: 0, first_read: new Date().toISOString(), ranged: true },
+      },
+    }, null, 2));
+    await runInstalledHook(hooksDir, "session-end.js", { session_id: sessionId }, root);
+    assertCompleteSession(root, sessionId, "session-end terminal reader");
+    const ledger = JSON.parse(fs.readFileSync(path.join(root, ".wolf", "token-ledger.json"), "utf-8"));
+    assert.strictEqual(ledger.lifetime.total_reads, 1);
+    assert.strictEqual(ledger.lifetime.total_writes, 0);
   });
 });


### PR DESCRIPTION
## Summary

- register Codex canonical `Bash` pre/post hooks so shell reads reach OpenWolf accounting
- recover and normalize complete session state when any hook arrives before `SessionStart`
- keep the current hook session ID authoritative over stale persisted state
- resolve project state from canonical hook cwd and relative Bash file paths from the command cwd
- accept Codex string `tool_response` values while preserving string/object response shape
- build compiled main/hooks code before package tests so clean checkouts cannot skip integration coverage

## Why

Codex commonly reads through `Bash`, but the adapter did not register Bash hooks. Codex supplies Bash output as a JSON string and runs hooks with the request cwd. Partial session files from pre/post hooks could also make later hooks crash, lose accounting, retain stale identity, or emit non-finite ledger totals. Claude Code shares the missed-SessionStart recovery path.

The fix centralizes recovery in the existing `readSessionState` boundary and routes every session read-modify-write path through it. Provider transcript parsing, dashboard code, and PR #95 are unchanged.

## Verification

- `npm test` — pretest builds main/hooks, 218/218 passed
- `npx --yes pnpm@9 test` — 218/218 passed
- `node --test tests/hook-health.test.ts` — 18/18 passed
- `npx --yes pnpm@9 build`
- `node dist/bin/openwolf.js --help`
- isolated checkout with no `dist`: `npm test` built compiled hooks and passed
- mutation checks killed raw partial writers, raw terminal readers, stale session identity, malformed token records, response-shape changes, and root-precedence changes
- nested-cwd regression proves `cat local.ts` is attributed to the command cwd while session/ledger state remains only in the active project

Tested on Linux with Node.js v26.7.0. This PR addresses accounting only; dashboard rendering remains isolated in #95.