### PR TITLE
fix: serialize concurrent session hook mutations

### DIFF
--- a/src/hooks/post-bash.ts
+++ b/src/hooks/post-bash.ts
@@ -2,8 +2,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
 import {
-  getWolfDir, ensureWolfDir, readJSON, writeJSON, readStdin, emitHookJSON,
-  hookMain, getSessionFilePath, normalizePath
+  getWolfDir, ensureWolfDir, readJSON, mutateSession, readStdin, emitHookJSON,
+  hookMain, getSessionFilePath, normalizePath, SessionLockTimeoutError
 } from "./shared.js";
 import {
   classifyCommand, condenseOutput, estimateTokens,
@@ -78,37 +78,39 @@ async function main(): Promise<void> {
     if (read && stdout.length > 0) {
       const normalized = normalizePath(path.isAbsolute(read.file) ? read.file : path.join(process.env.CLAUDE_PROJECT_DIR ?? process.cwd(), read.file));
       if (!normalized.includes("/.wolf/")) {
-        const session = readJSON<{ files_read?: Record<string, { count: number; tokens: number; first_read: string; ranged?: boolean; read_mtime?: number; via_bash?: boolean }> }>(sessionFile, {});
-        if (!session.files_read) session.files_read = {};
-        const prev = session.files_read[normalized];
-        let unchanged = false;
-        let mtime: number | undefined;
-        try {
-          mtime = fs.statSync(normalized).mtimeMs;
-          unchanged = prev?.read_mtime !== undefined && mtime <= prev.read_mtime!;
-        } catch {}
-        if (read.full && prev && prev.ranged !== true && unchanged && prev.tokens > 0) {
-          notes.push(
-            `OpenWolf: ${path.basename(normalized)} was already fully output this session (~${prev.tokens} tok) and is unchanged on disk since.`
-          );
-          prev.count++;
-        } else if (read.full) {
-          session.files_read[normalized] = {
-            count: (prev?.count ?? 0) + 1,
-            tokens: estimateTokens(stdout),
-            first_read: prev?.first_read ?? new Date().toISOString(),
-            read_mtime: mtime,
-            via_bash: true,
-          };
-        } else if (!prev) {
-          session.files_read[normalized] = {
-            count: 1, tokens: 0, first_read: new Date().toISOString(), ranged: true, read_mtime: mtime, via_bash: true,
-          };
-        }
-        writeJSON(sessionFile, session);
+        await mutateSession<{ files_read?: Record<string, { count: number; tokens: number; first_read: string; ranged?: boolean; read_mtime?: number; via_bash?: boolean }> }>(sessionFile, {}, (session) => {
+          if (!session.files_read) session.files_read = {};
+          const prev = session.files_read[normalized];
+          let unchanged = false;
+          let mtime: number | undefined;
+          try {
+            mtime = fs.statSync(normalized).mtimeMs;
+            unchanged = prev?.read_mtime !== undefined && mtime <= prev.read_mtime!;
+          } catch {}
+          if (read.full && prev && prev.ranged !== true && unchanged && prev.tokens > 0) {
+            notes.push(
+              `OpenWolf: ${path.basename(normalized)} was already fully output this session (~${prev.tokens} tok) and is unchanged on disk since.`
+            );
+            prev.count++;
+          } else if (read.full) {
+            session.files_read[normalized] = {
+              count: (prev?.count ?? 0) + 1,
+              tokens: estimateTokens(stdout),
+              first_read: prev?.first_read ?? new Date().toISOString(),
+              read_mtime: mtime,
+              via_bash: true,
+            };
+          } else if (!prev) {
+            session.files_read[normalized] = {
+              count: 1, tokens: 0, first_read: new Date().toISOString(), ranged: true, read_mtime: mtime, via_bash: true,
+            };
+          }
+        });
       }
     }
-  } catch {}
+  } catch (error) {
+    if (error instanceof SessionLockTimeoutError) throw error;
+  }
 
   // ── Output governor ───────────────────────────────────────────────────────
   const config = governorConfig(wolfDir);
@@ -144,10 +146,12 @@ async function main(): Promise<void> {
           at: new Date().toISOString(),
         };
         try {
-          const session = readJSON<{ bash_governed?: GovernedRecord[] }>(sessionFile, {});
-          session.bash_governed = [...(session.bash_governed ?? []), record].slice(-200);
-          writeJSON(sessionFile, session);
-        } catch {}
+          await mutateSession<{ bash_governed?: GovernedRecord[] }>(sessionFile, {}, (session) => {
+            session.bash_governed = [...(session.bash_governed ?? []), record].slice(-200);
+          });
+        } catch (error) {
+          if (error instanceof SessionLockTimeoutError) throw error;
+        }
 
         if (effectiveAction === "replace") {
           // Mirror the received object exactly; change ONLY stdout. A shape

--- a/src/hooks/post-read.ts
+++ b/src/hooks/post-read.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { getWolfDir, ensureWolfDir, readJSON, writeJSON, estimateTokens, readStdin, normalizePath, getProjectDir, hookMain, getSessionFilePath } from "./shared.js";
+import { getWolfDir, ensureWolfDir, mutateSession, estimateTokens, readStdin, normalizePath, getProjectDir, hookMain, getSessionFilePath, SessionLockTimeoutError } from "./shared.js";
 import { lookupEntry } from "./anatomy-store.js";
 
 interface SessionData {
@@ -71,15 +71,17 @@ async function main(): Promise<void> {
     // separately from project reads so anatomy hit-rates stay meaningful.
     try {
       if (content) {
-        const session = readJSON<SessionData>(sessionFile, { files_read: {} });
-        const tok = estimateTokens(content, "prose");
-        session.wolf_internal_tokens = ((session.wolf_internal_tokens as number) ?? 0) + tok;
-        const perFile = (session.wolf_internal_reads ?? {}) as Record<string, number>;
-        perFile[relToProject] = (perFile[relToProject] ?? 0) + tok;
-        session.wolf_internal_reads = perFile;
-        writeJSON(sessionFile, session);
+        await mutateSession<SessionData>(sessionFile, { files_read: {} }, (session) => {
+          const tok = estimateTokens(content, "prose");
+          session.wolf_internal_tokens = ((session.wolf_internal_tokens as number) ?? 0) + tok;
+          const perFile = (session.wolf_internal_reads ?? {}) as Record<string, number>;
+          perFile[relToProject] = (perFile[relToProject] ?? 0) + tok;
+          session.wolf_internal_reads = perFile;
+        });
       }
-    } catch {}
+    } catch (error) {
+      if (error instanceof SessionLockTimeoutError) throw error;
+    }
     return;
   }
 
@@ -96,20 +98,19 @@ async function main(): Promise<void> {
     if (entry) tokens = entry.tokens;
   }
 
-  const session = readJSON<SessionData>(sessionFile, { files_read: {} });
-  const existing = session.files_read[normalizedFile];
-  if (existing && existing.ranged !== true) {
-    existing.tokens = tokens;
-  } else {
-    // Fresh full read (or an upgrade of a ranged-only contact to a full read).
-    session.files_read[normalizedFile] = {
-      count: 1,
-      tokens,
-      first_read: existing?.first_read ?? new Date().toISOString(),
-    };
-  }
-
-  writeJSON(sessionFile, session);
+  await mutateSession<SessionData>(sessionFile, { files_read: {} }, (session) => {
+    const existing = session.files_read[normalizedFile];
+    if (existing && existing.ranged !== true) {
+      existing.tokens = tokens;
+    } else {
+      // Fresh full read (or an upgrade of a ranged-only contact to a full read).
+      session.files_read[normalizedFile] = {
+        count: 1,
+        tokens,
+        first_read: existing?.first_read ?? new Date().toISOString(),
+      };
+    }
+  });
 }
 
 hookMain("post-read", main);

--- a/src/hooks/post-read.ts
+++ b/src/hooks/post-read.ts
@@ -99,6 +99,7 @@ async function main(): Promise<void> {
   }
 
   await mutateSession<SessionData>(sessionFile, { files_read: {} }, (session) => {
+    if (!session.files_read) session.files_read = {};
     const existing = session.files_read[normalizedFile];
     if (existing && existing.ranged !== true) {
       existing.tokens = tokens;

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -189,6 +189,26 @@ export function writeJSON(filePath: string, data: unknown): void {
   }
 }
 
+export class SessionLockTimeoutError extends Error {
+  constructor(sessionFile: string) {
+    super(`Session lock exhausted for ${sessionFile}`);
+    this.name = "SessionLockTimeoutError";
+  }
+}
+
+/** Serialize one session's complete read-mutate-atomic-write transaction. */
+export async function mutateSession<T>(sessionFile: string, fallback: T, mutate: (session: T) => void): Promise<void> {
+  const { HOOK_LOCK_BUDGET_MS, withFileLock } = await import("./anatomy-lock.js");
+  const dir = path.dirname(sessionFile);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const result = withFileLock(`${sessionFile}.lock`, HOOK_LOCK_BUDGET_MS, () => {
+    const session = readJSON<T>(sessionFile, fallback);
+    mutate(session);
+    writeJSON(sessionFile, session);
+  });
+  if (result === null) throw new SessionLockTimeoutError(sessionFile);
+}
+
 export function readMarkdown(filePath: string): string {
   try {
     return fs.readFileSync(filePath, "utf-8");

--- a/tests/hook-health.test.ts
+++ b/tests/hook-health.test.ts
@@ -280,6 +280,22 @@ describe("public session transactions", { skip: !haveDist ? "dist/hooks not buil
     }
   });
 
+  test("post-read preserves governor-only session state while adding a read", async () => {
+    const { root, hooksDir } = installHooks();
+    const sessionId = "governor-only";
+    const sessionDir = path.join(hooksDir, "sessions");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const governor = [{ family: "file_print", action: "replaced", original_tokens: 9, entered_tokens: 4, at: "now" }];
+    fs.writeFileSync(path.join(sessionDir, `${sessionId}.json`), JSON.stringify({ bash_governed: governor }));
+    const target = path.join(root, "after-governor.ts");
+
+    await runHooks(hooksDir, root, [{ file: "post-read.js", payload: postReadPayload(sessionId, target) }]);
+
+    const state = readSession(hooksDir, sessionId);
+    assert.deepStrictEqual(state.bash_governed, governor);
+    assert.ok(state.files_read?.[target]);
+  });
+
   test("retains session recovery, legacy fallback, and post-read response parsing contracts", async () => {
     const { root, hooksDir } = installHooks();
     const sessionDir = path.join(hooksDir, "sessions");

--- a/tests/hook-health.test.ts
+++ b/tests/hook-health.test.ts
@@ -140,3 +140,164 @@ describe("compiled hook integration", { skip: !haveDist ? "dist/hooks not built"
     assert.ok(fs.existsSync(path.join(hooksDir, "sessions", "sessB.json")));
   });
 });
+
+describe("public session transactions", { skip: !haveDist ? "dist/hooks not built" : false }, () => {
+  function installHooks(): { root: string; hooksDir: string } {
+    const root = tmpProject();
+    const hooksDir = path.join(root, ".wolf", "hooks");
+    for (const file of fs.readdirSync(DIST_HOOKS)) {
+      if (file.endsWith(".js")) fs.copyFileSync(path.join(DIST_HOOKS, file), path.join(hooksDir, file));
+    }
+    fs.writeFileSync(path.join(hooksDir, "package.json"), JSON.stringify({ type: "module" }));
+    return { root, hooksDir };
+  }
+
+  function startHook(hooksDir: string, root: string, file: string): { child: ReturnType<typeof execFile>; done: Promise<string> } {
+    let resolve!: (stdout: string) => void;
+    let reject!: (error: Error) => void;
+    const done = new Promise<string>((onResolve, onReject) => {
+      resolve = onResolve;
+      reject = onReject;
+    });
+    const child = execFile(
+      process.execPath,
+      [path.join(hooksDir, file)],
+      { env: { ...process.env, CLAUDE_PROJECT_DIR: root }, timeout: 10000, maxBuffer: 10 * 1024 * 1024 },
+      (error, stdout) => error ? reject(error) : resolve(stdout)
+    );
+    return { child, done };
+  }
+
+  async function runHooks(
+    hooksDir: string,
+    root: string,
+    requests: Array<{ file: string; payload: unknown }>
+  ): Promise<string[]> {
+    const started = requests.map(({ file }) => startHook(hooksDir, root, file));
+    for (let index = 0; index < started.length; index++) {
+      started[index].child.stdin!.end(JSON.stringify(requests[index].payload));
+    }
+    return Promise.all(started.map(({ done }) => done));
+  }
+
+  function postReadPayload(sessionId: string, file: string, content = "export const value = 1;\n"): object {
+    return {
+      session_id: sessionId,
+      tool_input: { file_path: file },
+      tool_response: { file: { content } },
+    };
+  }
+
+  function readSession(hooksDir: string, sessionId: string): Record<string, any> {
+    return JSON.parse(fs.readFileSync(path.join(hooksDir, "sessions", `${sessionId}.json`), "utf-8"));
+  }
+
+  test("preserves every sequential and concurrent post-read fact without torn JSON", async () => {
+    const { root, hooksDir } = installHooks();
+    const sequential = "sequential-reads";
+    const concurrent = "concurrent-reads";
+    const sequentialFiles = Array.from({ length: 60 }, (_, i) => path.join(root, `sequential-${i}.ts`));
+    const concurrentFiles = Array.from({ length: 60 }, (_, i) => path.join(root, `concurrent-${i}.ts`));
+
+    for (const file of sequentialFiles) {
+      await runHooks(hooksDir, root, [{ file: "post-read.js", payload: postReadPayload(sequential, file) }]);
+    }
+    assert.deepStrictEqual(Object.keys(readSession(hooksDir, sequential).files_read).sort(), sequentialFiles.sort());
+
+    const sessionDir = path.join(hooksDir, "sessions");
+    const sessionFile = `${concurrent}.json`;
+    const parseFailures: string[] = [];
+    let observedReplacements = 0;
+    const watcher = fs.watch(sessionDir, (_event, changed) => {
+      if (changed === sessionFile && fs.existsSync(path.join(sessionDir, sessionFile))) {
+        observedReplacements++;
+        try {
+          JSON.parse(fs.readFileSync(path.join(sessionDir, sessionFile), "utf-8"));
+        } catch (error) {
+          parseFailures.push(String(error));
+        }
+      }
+    });
+    try {
+      await runHooks(hooksDir, root, concurrentFiles.map((file) => ({ file: "post-read.js", payload: postReadPayload(concurrent, file) })));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    } finally {
+      watcher.close();
+    }
+    const state = readSession(hooksDir, concurrent);
+    assert.deepStrictEqual(Object.keys(state.files_read).sort(), concurrentFiles.sort());
+    assert.ok(observedReplacements > 0, "expected atomic session replacements to be observable");
+    assert.deepStrictEqual(parseFailures, []);
+    assert.deepStrictEqual(fs.readdirSync(sessionDir).filter((file) => file.endsWith(".tmp")), []);
+  });
+
+  test("composes concurrent post-read and post-bash mutations", async () => {
+    const { root, hooksDir } = installHooks();
+    const sessionId = "mixed-hooks";
+    const reads = Array.from({ length: 30 }, (_, i) => path.join(root, `read-${i}.ts`));
+    const bashReads = Array.from({ length: 30 }, (_, i) => path.join(root, `bash-${i}.ts`));
+    const oversized = "line\n".repeat(3000);
+    const output = await runHooks(hooksDir, root, [
+      ...reads.map((file) => ({ file: "post-read.js", payload: postReadPayload(sessionId, file) })),
+      ...bashReads.map((file, index) => ({
+        file: "post-bash.js",
+        payload: {
+          session_id: sessionId,
+          tool_use_id: `mixed-${index}`,
+          tool_input: { command: `cat ${file}` },
+          tool_response: { stdout: oversized, stderr: "", interrupted: false, isImage: false },
+        },
+      })),
+    ]);
+    for (const stdout of output.slice(reads.length)) assert.doesNotThrow(() => JSON.parse(stdout));
+    const state = readSession(hooksDir, sessionId);
+    assert.deepStrictEqual(Object.keys(state.files_read).sort(), [...reads, ...bashReads].sort());
+    assert.strictEqual(state.bash_governed.length, bashReads.length);
+  });
+
+  test("uses session-specific locks and reports same-session exhaustion without mutation", async () => {
+    const { root, hooksDir } = installHooks();
+    const sessionDir = path.join(hooksDir, "sessions");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const liveLock = JSON.stringify({ pid: process.pid, hostname: os.hostname(), acquiredAt: Date.now() });
+    const locked = "locked-session";
+    const independent = "independent-session";
+    const lockedFile = path.join(sessionDir, `${locked}.json`);
+    const before = JSON.stringify({ files_read: { before: { count: 1, tokens: 1, first_read: "now" } } });
+    fs.writeFileSync(lockedFile, before);
+    fs.writeFileSync(`${lockedFile}.lock`, liveLock);
+    try {
+      await runHooks(hooksDir, root, [{ file: "post-read.js", payload: postReadPayload(independent, path.join(root, "independent.ts")) }]);
+      assert.ok(fs.existsSync(path.join(sessionDir, `${independent}.json`)));
+
+      const output = await runHooks(hooksDir, root, [{ file: "post-read.js", payload: postReadPayload(locked, path.join(root, "blocked.ts")) }]);
+      assert.strictEqual(output[0], "");
+      assert.strictEqual(fs.readFileSync(lockedFile, "utf-8"), before);
+      const heartbeat = JSON.parse(fs.readFileSync(path.join(hooksDir, "_heartbeat.json"), "utf-8"));
+      assert.match(heartbeat["post-read"].last_error_message, /session lock exhausted/i);
+    } finally {
+      fs.unlinkSync(`${lockedFile}.lock`);
+    }
+  });
+
+  test("retains session recovery, legacy fallback, and post-read response parsing contracts", async () => {
+    const { root, hooksDir } = installHooks();
+    const sessionDir = path.join(hooksDir, "sessions");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const corrupt = "corrupt-session";
+    fs.writeFileSync(path.join(sessionDir, `${corrupt}.json`), "{");
+    const fromArray = path.join(root, "array-response.ts");
+    await runHooks(hooksDir, root, [{
+      file: "post-read.js",
+      payload: { session_id: corrupt, tool_input: { file_path: fromArray }, tool_response: [{ text: "const arrayResponse = true;" }] },
+    }]);
+    const recovered = readSession(hooksDir, corrupt);
+    assert.ok(recovered.files_read[fromArray].tokens > 0);
+
+    await runHooks(hooksDir, root, [{
+      file: "post-read.js",
+      payload: { session_id: "../bad", tool_input: { file_path: path.join(root, "legacy.ts") }, tool_response: "legacy" },
+    }]);
+    assert.ok(fs.existsSync(path.join(hooksDir, "_session.json")));
+  });
+});


### PR DESCRIPTION
## Summary

- serialize complete per-session read-mutate-atomic-write transactions for post-read and post-bash hooks
- preserve normalized session defaults and add public multi-process concurrency, isolation, timeout, and atomic-write regressions

## Verification

- pnpm build:hooks
- focused public hook suites: 47 passed
- full suite: 206 passed, 1 skipped
- GSD Antigravity review: PASS
- GSD verification: 6/6 must-haves passed

Fixes #83