### PR TITLE
fix: contain read accounting to project

### DIFF
--- a/src/hooks/post-bash.ts
+++ b/src/hooks/post-bash.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import * as crypto from "node:crypto";
 import {
   getWolfDir, ensureWolfDir, readJSON, writeJSON, readStdin, emitHookJSON,
-  hookMain, getSessionFilePath, normalizePath
+  hookMain, getSessionFilePath, normalizePath, getProjectDir, isPathWithinProject
 } from "./shared.js";
 import {
   classifyCommand, condenseOutput, estimateTokens,
@@ -75,8 +75,8 @@ async function main(): Promise<void> {
   // ── Bash-channel read registration + dedupe advisory ──────────────────────
   try {
     const read = parseBashRead(command);
-    if (read && stdout.length > 0) {
-      const normalized = normalizePath(path.isAbsolute(read.file) ? read.file : path.join(process.env.CLAUDE_PROJECT_DIR ?? process.cwd(), read.file));
+    if (read && stdout.length > 0 && isPathWithinProject(getProjectDir(), read.file, process.cwd())) {
+      const normalized = normalizePath(path.resolve(process.cwd(), read.file));
       if (!normalized.includes("/.wolf/")) {
         const session = readJSON<{ files_read?: Record<string, { count: number; tokens: number; first_read: string; ranged?: boolean; read_mtime?: number; via_bash?: boolean }> }>(sessionFile, {});
         if (!session.files_read) session.files_read = {};

--- a/src/hooks/post-read.ts
+++ b/src/hooks/post-read.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { getWolfDir, ensureWolfDir, readJSON, writeJSON, estimateTokens, readStdin, normalizePath, getProjectDir, hookMain, getSessionFilePath } from "./shared.js";
+import { getWolfDir, ensureWolfDir, readJSON, writeJSON, estimateTokens, readStdin, normalizePath, getProjectDir, hookMain, getSessionFilePath, isPathWithinProject } from "./shared.js";
 import { lookupEntry } from "./anatomy-store.js";
 
 interface SessionData {
@@ -52,6 +52,9 @@ async function main(): Promise<void> {
   const content = extractToolResponseText(input.tool_response) || input.tool_output?.content || "";
   if (!filePath) { return; }
 
+  const projectDir = normalizePath(path.resolve(getProjectDir()));
+  if (!isPathWithinProject(projectDir, filePath)) return;
+
   // Ranged reads: pre-read already recorded the contact with ranged:true.
   // Registering them as full reads here is what used to make a later
   // legitimate full read look like a duplicate (~20x warning inflation).
@@ -59,10 +62,9 @@ async function main(): Promise<void> {
     return;
   }
 
-  const normalizedFile = normalizePath(filePath);
+  const normalizedFile = normalizePath(path.resolve(filePath));
 
   // Skip tracking for .wolf/ internal files — consistent with pre-read
-  const projectDir = normalizePath(getProjectDir());
   const relToProject = normalizedFile.startsWith(projectDir)
     ? normalizedFile.slice(projectDir.length).replace(/^\//, "")
     : "";

--- a/src/hooks/pre-read.ts
+++ b/src/hooks/pre-read.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import {
   getWolfDir, ensureWolfDir, readJSON, writeJSON,
   estimateTokens, readStdin, normalizePath, getProjectDir, emitHookJSON, recordInjection,
-  hookMain, getSessionFilePath
+  hookMain, getSessionFilePath, isPathWithinProject
 } from "./shared.js";
 import { lookupEntry } from "./anatomy-store.js";
 
@@ -71,6 +71,9 @@ async function main(): Promise<void> {
   const filePath = input.tool_input?.file_path ?? input.tool_input?.path ?? "";
   if (!filePath) { return; }
 
+  const projectDir = normalizePath(path.resolve(getProjectDir()));
+  if (!isPathWithinProject(projectDir, filePath)) return;
+
   // Ranged reads (offset/limit) are exactly what the symbol hints steer the
   // model toward — never warn about, deny, or record them as full reads (a
   // ranged first contact must not make a later legitimate full read look like
@@ -81,11 +84,10 @@ async function main(): Promise<void> {
   // handling stays hands-off for them.
   const isSubagent = typeof input.agent_id === "string" && input.agent_id.length > 0;
 
-  const normalizedFile = normalizePath(filePath);
+  const normalizedFile = normalizePath(path.resolve(filePath));
 
   // Skip tracking for .wolf/ internal files — they're infrastructure, not project files.
   // Counting them inflates anatomy miss rates since .wolf/ is excluded from anatomy scanning.
-  const projectDir = normalizePath(getProjectDir());
   const relToProject = normalizedFile.startsWith(projectDir)
     ? normalizedFile.slice(projectDir.length).replace(/^\//, "")
     : "";

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -35,6 +35,11 @@ export function getProjectDir(): string {
   );
 }
 
+export function isPathWithinProject(projectRoot: string, candidate: string, candidateCwd = process.cwd()): boolean {
+  const relative = path.relative(path.resolve(projectRoot), path.resolve(candidateCwd, candidate));
+  return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
 export function getWolfDir(): string {
   return path.join(getProjectDir(), ".wolf");
 }

--- a/tests/hook-health.test.ts
+++ b/tests/hook-health.test.ts
@@ -82,13 +82,41 @@ describe("session keying", () => {
 });
 
 describe("compiled hook integration", { skip: !haveDist ? "dist/hooks not built" : false }, () => {
-  test("--selfcheck passes on a healthy install and fails on a broken one", () => {
+  function installHooks(): { root: string; hooksDir: string } {
     const root = tmpProject();
     const hooksDir = path.join(root, ".wolf", "hooks");
     for (const f of fs.readdirSync(DIST_HOOKS)) {
       if (f.endsWith(".js")) fs.copyFileSync(path.join(DIST_HOOKS, f), path.join(hooksDir, f));
     }
     fs.writeFileSync(path.join(hooksDir, "package.json"), JSON.stringify({ type: "module" }));
+    return { root, hooksDir };
+  }
+
+  function runHook(
+    hooksDir: string,
+    root: string,
+    file: string,
+    payload: unknown,
+    cwd = root
+  ): Promise<{ stdout: string }> {
+    return new Promise((resolve, reject) => {
+      const child = execFile(
+        process.execPath,
+        [path.join(hooksDir, file)],
+        { cwd, env: { ...process.env, CLAUDE_PROJECT_DIR: root }, timeout: 10000 },
+        (err, stdout) => (err ? reject(err) : resolve({ stdout }))
+      );
+      child.stdin!.end(JSON.stringify(payload));
+    });
+  }
+
+  function readSession(root: string, sessionId: string): Record<string, any> | null {
+    const file = path.join(root, ".wolf", "hooks", "sessions", `${sessionId}.json`);
+    return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, "utf-8")) : null;
+  }
+
+  test("--selfcheck passes on a healthy install and fails on a broken one", () => {
+    const { root, hooksDir } = installHooks();
 
     const out = execFileSync(process.execPath, [path.join(hooksDir, "pre-read.js"), "--selfcheck"], { encoding: "utf-8" });
     assert.ok(out.includes("ok pre-read"));
@@ -101,42 +129,94 @@ describe("compiled hook integration", { skip: !haveDist ? "dist/hooks not built"
   });
 
   test("two sessions do not cross-contaminate duplicate tracking", async () => {
-    const root = tmpProject();
-    const hooksDir = path.join(root, ".wolf", "hooks");
-    for (const f of fs.readdirSync(DIST_HOOKS)) {
-      if (f.endsWith(".js")) fs.copyFileSync(path.join(DIST_HOOKS, f), path.join(hooksDir, f));
-    }
-    fs.writeFileSync(path.join(hooksDir, "package.json"), JSON.stringify({ type: "module" }));
+    const { root, hooksDir } = installHooks();
     const target = path.join(root, "src.ts");
     fs.writeFileSync(target, "export const x = 1;\n");
 
-    const runHook = (file: string, payload: unknown): Promise<{ stdout: string }> =>
-      new Promise((resolve, reject) => {
-        const child = execFile(
-          process.execPath,
-          [path.join(hooksDir, file)],
-          { env: { ...process.env, CLAUDE_PROJECT_DIR: root }, timeout: 10000 },
-          (err, stdout) => (err ? reject(err) : resolve({ stdout }))
-        );
-        child.stdin!.end(JSON.stringify(payload));
-      });
-
     // Session A reads the file twice (full): pre-read + post-read then pre-read again.
-    await runHook("pre-read.js", { session_id: "sessA", tool_input: { file_path: target } });
-    await runHook("post-read.js", { session_id: "sessA", tool_input: { file_path: target }, tool_response: { file: { content: "export const x = 1;\n" } } });
-    const dupA = await runHook("pre-read.js", { session_id: "sessA", tool_input: { file_path: target } });
+    await runHook(hooksDir, root, "pre-read.js", { session_id: "sessA", tool_input: { file_path: target } });
+    await runHook(hooksDir, root, "post-read.js", { session_id: "sessA", tool_input: { file_path: target }, tool_response: { file: { content: "export const x = 1;\n" } } });
+    const dupA = await runHook(hooksDir, root, "pre-read.js", { session_id: "sessA", tool_input: { file_path: target } });
     assert.ok(dupA.stdout.includes("already read this session"), "same session sees the duplicate warning");
 
     // Session B reads the same file for the FIRST time: no warning.
-    const freshB = await runHook("pre-read.js", { session_id: "sessB", tool_input: { file_path: target } });
+    const freshB = await runHook(hooksDir, root, "pre-read.js", { session_id: "sessB", tool_input: { file_path: target } });
     assert.ok(!freshB.stdout.includes("already read this session"), "other session must not inherit A's reads");
 
     // Ranged read in a third session then a full read: no duplicate warning.
-    await runHook("pre-read.js", { session_id: "sessC", tool_input: { file_path: target, offset: 1, limit: 1 } });
-    const fullAfterRanged = await runHook("pre-read.js", { session_id: "sessC", tool_input: { file_path: target } });
+    await runHook(hooksDir, root, "pre-read.js", { session_id: "sessC", tool_input: { file_path: target, offset: 1, limit: 1 } });
+    const fullAfterRanged = await runHook(hooksDir, root, "pre-read.js", { session_id: "sessC", tool_input: { file_path: target } });
     assert.ok(!fullAfterRanged.stdout.includes("already read this session"), "ranged contact must not mark the file as fully read");
 
     assert.ok(fs.existsSync(path.join(hooksDir, "sessions", "sessA.json")));
     assert.ok(fs.existsSync(path.join(hooksDir, "sessions", "sessB.json")));
+  });
+
+  test("project read state stays lexically contained across public hooks", async () => {
+    const { root, hooksDir } = installHooks();
+    const sibling = `${root}-private/secret.ts`;
+    const parent = path.join(path.dirname(root), `${path.basename(root)}-parent.ts`);
+    const unrelated = path.join(os.tmpdir(), `unrelated-${path.basename(root)}.ts`);
+    const external = [sibling, parent, unrelated];
+    const hooks = ["pre-read.js", "post-read.js", "post-bash.js"];
+
+    for (const [hookIndex, hook] of hooks.entries()) {
+      for (const [pathIndex, candidate] of external.entries()) {
+        const sessionId = `outside-${hookIndex}-${pathIndex}`;
+        const payload = hook === "pre-read.js"
+          ? { session_id: sessionId, tool_input: { file_path: candidate } }
+          : hook === "post-read.js"
+            ? { session_id: sessionId, tool_input: { file_path: candidate }, tool_response: { file: { content: "external\n" } } }
+            : { session_id: sessionId, tool_input: { command: `cat ${candidate}` }, tool_response: { stdout: "external\n", stderr: "" } };
+        await runHook(hooksDir, root, hook, payload);
+        const state = readSession(root, sessionId);
+        assert.deepStrictEqual(state?.files_read ?? {}, {}, `${hook} recorded external path ${candidate}`);
+      }
+    }
+
+    const externalCwd = fs.mkdtempSync(path.join(os.tmpdir(), "wolf-hh-cwd-"));
+    fs.writeFileSync(path.join(externalCwd, "relative.ts"), "external\n");
+    await runHook(
+      hooksDir,
+      root,
+      "post-bash.js",
+      { session_id: "outside-cwd", tool_input: { command: "cat relative.ts" }, tool_response: { stdout: "external\n", stderr: "" } },
+      externalCwd
+    );
+    assert.deepStrictEqual(readSession(root, "outside-cwd")?.files_read ?? {}, {}, "relative Bash read must resolve from subprocess cwd");
+
+    const descendants = [path.join(root, "src", "child.ts"), path.join(root, "..notes.ts")];
+    fs.mkdirSync(path.dirname(descendants[0]), { recursive: true });
+    for (const candidate of descendants) fs.writeFileSync(candidate, "inside\n");
+    for (const [hookIndex, hook] of hooks.entries()) {
+      for (const [pathIndex, candidate] of descendants.entries()) {
+        const sessionId = `inside-${hookIndex}-${pathIndex}`;
+        const payload = hook === "pre-read.js"
+          ? { session_id: sessionId, tool_input: { file_path: candidate } }
+          : hook === "post-read.js"
+            ? { session_id: sessionId, tool_input: { file_path: candidate }, tool_response: { file: { content: "inside\n" } } }
+            : { session_id: sessionId, tool_input: { command: `cat ${candidate}` }, tool_response: { stdout: "inside\n", stderr: "" } };
+        await runHook(hooksDir, root, hook, payload);
+        assert.ok(readSession(root, sessionId)?.files_read?.[candidate], `${hook} rejected project path ${candidate}`);
+      }
+    }
+
+    const anatomy = path.join(root, ".wolf", "anatomy.md");
+    fs.writeFileSync(anatomy, "# anatomy\n".repeat(700));
+    const preInternal = await runHook(hooksDir, root, "pre-read.js", {
+      session_id: "wolf-pre",
+      tool_input: { file_path: anatomy },
+    });
+    assert.ok(preInternal.stdout.includes("index, not a document"), "pre-read advice remains active");
+    assert.strictEqual(readSession(root, "wolf-pre")?.wolf_read_advised?.["anatomy.md"], true);
+
+    await runHook(hooksDir, root, "post-read.js", {
+      session_id: "wolf-post",
+      tool_input: { file_path: anatomy },
+      tool_response: { file: { content: "internal context\n" } },
+    });
+    const internalState = readSession(root, "wolf-post");
+    assert.ok(internalState?.wolf_internal_tokens > 0, "post-read internal token accounting remains active");
+    assert.ok(internalState?.wolf_internal_reads?.[".wolf/anatomy.md"] > 0);
   });
 });


### PR DESCRIPTION
## What

Confines Read and Bash hook accounting to lexical descendants of the configured project root.

Addresses #80.

## Why

Paths outside the project could be counted or receive project advice when they shared the project's string prefix or when Bash-relative reads were resolved against the wrong working directory.

## How

- Uses a shared `path.relative()` containment predicate with path-segment boundaries.
- Exits before session mutation or `.wolf` advice for sibling, parent, and unrelated paths.
- Resolves Bash-relative reads from the command's actual working directory.
- Adds public compiled-hook regression tests for external paths and valid descendants.

Verification: `pnpm build:hooks`; `pnpm test` — 203 tests, 202 passed, 0 failed, 1 pre-existing skip. GSD Antigravity complete-diff review: `VERDICT: PASS`.

