### PR TITLE
fix(hooks): prevent dead Bash cache pointers

### DIFF
--- a/src/hooks/post-bash.ts
+++ b/src/hooks/post-bash.ts
@@ -130,11 +130,7 @@ async function main(): Promise<void> {
       if (result) {
         // Preserve the full output regardless of action: the pointer (or the
         // suggestion) must always be honest about where the bytes live.
-        try {
-          fs.mkdirSync(logDir, { recursive: true });
-          fs.writeFileSync(logPath, stdout, "utf-8");
-          pruneLogs(logDir);
-        } catch {}
+        if (retainCompleteLog(logDir, logPath, stdout)) {
 
         const record: GovernedRecord = {
           family,
@@ -161,6 +157,7 @@ async function main(): Promise<void> {
         notes.push(
           `OpenWolf: that ${family.replace("_", " ")} output was ~${result.original_tokens.toLocaleString("en-US")} tokens and now sits in context for the rest of the session. A copy is saved at ${relLog}. Narrower variants (grep with a file filter, head/tail, git show --stat) produce the same information at a fraction of the cost.`
         );
+        }
       }
     }
   }
@@ -170,25 +167,44 @@ async function main(): Promise<void> {
   }
 }
 
-/** Keep the bash log cache bounded (200 files / ~50MB, oldest first). */
-function pruneLogs(logDir: string): void {
+const MAX_LOG_FILES = 200;
+const MAX_LOG_BYTES = 50 * 1024 * 1024;
+
+/** Retain a complete current log while keeping the cache within fixed limits. */
+function retainCompleteLog(logDir: string, logPath: string, stdout: string): boolean {
+  const expectedBytes = Buffer.byteLength(stdout, "utf8");
+  if (expectedBytes > MAX_LOG_BYTES) return false;
   try {
-    const files = fs.readdirSync(logDir)
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(logPath, stdout, "utf-8");
+    let files = fs.readdirSync(logDir)
       .filter((f) => f.endsWith(".log"))
       .map((f) => {
         const p = path.join(logDir, f);
         const st = fs.statSync(p);
+        if (!st.isFile()) throw new Error("bash cache entry is not a regular file");
         return { p, mtime: st.mtimeMs, size: st.size };
       })
-      .sort((a, b) => b.mtime - a.mtime);
-    let total = 0;
-    files.forEach((f, i) => {
-      total += f.size;
-      if (i >= 200 || total > 50 * 1024 * 1024) {
-        try { fs.unlinkSync(f.p); } catch {}
-      }
-    });
-  } catch {}
+      .sort((a, b) => a.mtime - b.mtime);
+    const current = files.find((f) => f.p === logPath);
+    if (!current || current.size !== expectedBytes) throw new Error("incomplete bash cache write");
+    let total = files.reduce((sum, file) => sum + file.size, 0);
+    for (const file of files) {
+      if (files.length <= MAX_LOG_FILES && total <= MAX_LOG_BYTES) break;
+      if (file.p === logPath) continue;
+      fs.unlinkSync(file.p);
+      files = files.filter((entry) => entry.p !== file.p);
+      total -= file.size;
+    }
+    const verified = fs.statSync(logPath);
+    if (!verified.isFile() || verified.size !== expectedBytes || files.length > MAX_LOG_FILES || total > MAX_LOG_BYTES) {
+      throw new Error("bash cache limits could not be verified");
+    }
+    return true;
+  } catch {
+    try { fs.unlinkSync(logPath); } catch {}
+    return false;
+  }
 }
 
 hookMain("post-bash", main);

--- a/tests/bash-governor.test.ts
+++ b/tests/bash-governor.test.ts
@@ -132,16 +132,55 @@ describe("post-bash compiled hook", { skip: !haveDist ? "dist not built" : false
     return { root, hooksDir };
   }
 
-  const runHook = (hooksDir: string, root: string, payload: unknown): Promise<string> =>
+  const runHook = (hooksDir: string, root: string, payload: unknown, extraEnv: Record<string, string> = {}): Promise<string> =>
     new Promise((resolve, reject) => {
       const child = execFile(
         process.execPath,
         [path.join(hooksDir, "post-bash.js")],
-        { env: { ...process.env, CLAUDE_PROJECT_DIR: root }, timeout: 10000, maxBuffer: 10 * 1024 * 1024 },
+        { env: { ...process.env, CLAUDE_PROJECT_DIR: root, ...extraEnv }, timeout: 30000, maxBuffer: 10 * 1024 * 1024 },
         (err, stdout) => (err ? reject(err) : resolve(stdout))
       );
       child.stdin!.end(JSON.stringify(payload));
     });
+
+  function faultPreload(root: string, method: "writeFileSync" | "statSync" | "unlinkSync", marker: string): string {
+    const preload = path.join(root, `fault-${method}.cjs`);
+    fs.writeFileSync(preload, `
+      const fs = require("node:fs");
+      const { syncBuiltinESMExports } = require("node:module");
+      const original = fs[${JSON.stringify(method)}];
+      let calls = 0;
+      fs[${JSON.stringify(method)}] = function (...args) {
+        const target = String(args[0] ?? "");
+        if (target.includes(".wolf/cache/bash") && calls++ === 0) {
+          fs.appendFileSync(${JSON.stringify(marker)}, target + "\\n");
+          throw new Error("injected ${method} failure");
+        }
+        return original.apply(this, args);
+      };
+      syncBuiltinESMExports();
+    `);
+    return preload;
+  }
+
+  function withPreload(preload: string, marker: string): Record<string, string> {
+    return { NODE_OPTIONS: `--require ${preload}`, WOLF_FAULT_MARKER: marker };
+  }
+
+  function unlinkSpyPreload(root: string, marker: string): string {
+    const preload = path.join(root, "unlink-spy.cjs");
+    fs.writeFileSync(preload, `
+      const fs = require("node:fs");
+      const { syncBuiltinESMExports } = require("node:module");
+      const original = fs.unlinkSync;
+      fs.unlinkSync = function (...args) {
+        fs.appendFileSync(${JSON.stringify(marker)}, String(args[0]) + "\\n");
+        return original.apply(this, args);
+      };
+      syncBuiltinESMExports();
+    `);
+    return preload;
+  }
 
   test("replaces an oversized grep flood and preserves the full log", async () => {
     const { root, hooksDir } = setupProject();
@@ -175,6 +214,21 @@ describe("post-bash compiled hook", { skip: !haveDist ? "dist not built" : false
     assert.ok(session.bash_governed[0].original_tokens > session.bash_governed[0].entered_tokens);
   });
 
+  test("replacement preserves string response shape and token accounting", async () => {
+    const { root, hooksDir } = setupProject();
+    const stdout = Array.from({ length: 900 }, (_, i) => `line ${i} with enough content to condense`).join("\n");
+    const out = await runHook(hooksDir, root, {
+      session_id: "string-replace", tool_use_id: "string-replace",
+      tool_input: { command: "cat string.log" }, tool_response: stdout,
+    });
+    const parsed = JSON.parse(out);
+    assert.strictEqual(typeof parsed.hookSpecificOutput.updatedToolOutput, "string");
+    assert.ok(parsed.hookSpecificOutput.updatedToolOutput.includes("Full output preserved verbatim"));
+    const session = JSON.parse(fs.readFileSync(path.join(hooksDir, "sessions", "string-replace.json"), "utf8"));
+    assert.strictEqual(session.bash_governed[0].action, "replaced");
+    assert.ok(session.bash_governed[0].entered_tokens < session.bash_governed[0].original_tokens);
+  });
+
   test("suggests (never replaces) for test-runner output, and stays silent under threshold", async () => {
     const { root, hooksDir } = setupProject();
     const bigTestOutput = Array.from({ length: 900 }, (_, i) => `PASS test case number ${i} with a description`).join("\n");
@@ -186,6 +240,9 @@ describe("post-bash compiled hook", { skip: !haveDist ? "dist not built" : false
     const parsed = JSON.parse(out);
     assert.strictEqual(parsed.hookSpecificOutput.updatedToolOutput, undefined);
     assert.ok(parsed.hookSpecificOutput.additionalContext.includes("saved at .wolf/cache/bash/"));
+    const session = JSON.parse(fs.readFileSync(path.join(hooksDir, "sessions", "gov2.json"), "utf-8"));
+    assert.deepStrictEqual(session.bash_governed[0].action, "suggested");
+    assert.strictEqual(session.bash_governed[0].entered_tokens, session.bash_governed[0].original_tokens);
 
     const quiet = await runHook(hooksDir, root, {
       session_id: "gov2",
@@ -220,12 +277,14 @@ describe("post-bash compiled hook", { skip: !haveDist ? "dist not built" : false
       const when = new Date(1_000 + i * 1_000);
       fs.utimesSync(old, when, when);
     }
+    const unlinkCalls = path.join(root, "unlink.calls");
+    const unlinkPreload = unlinkSpyPreload(root, unlinkCalls);
     const stdout = "x\n".repeat(25 * 1024 * 1024);
     const out = await runHook(hooksDir, root, {
       session_id: "exact-cap", tool_use_id: "exact-cap",
       tool_input: { command: "cat big.log" },
       tool_response: { stdout, stderr: "same", interrupted: false, isImage: false },
-    });
+    }, { NODE_OPTIONS: `--require ${unlinkPreload}` });
     const updated = JSON.parse(out).hookSpecificOutput.updatedToolOutput;
     assert.ok(updated, "exact-cap output must be replaced only after retention");
     const current = path.join(cacheDir, "exact-cap.log");
@@ -234,6 +293,75 @@ describe("post-bash compiled hook", { skip: !haveDist ? "dist not built" : false
     const bytes = logs.reduce((sum, f) => sum + fs.statSync(path.join(cacheDir, f)).size, 0);
     assert.ok(logs.length <= 200 && bytes <= 50 * 1024 * 1024);
     assert.ok(!fs.existsSync(path.join(cacheDir, "old-000.log")), "oldest log must be evicted");
+    const calls = fs.readFileSync(unlinkCalls, "utf8").trim().split("\n");
+    assert.ok(calls[0].endsWith("old-000.log"), "oldest eligible log must be removed first");
+    assert.ok(!calls.some((call) => call.endsWith("exact-cap.log")), "current log must be protected");
+  });
+
+  test("issue #4: multibyte UTF-8 retention uses encoded bytes", async () => {
+    const { root, hooksDir } = setupProject();
+    const stdout = "é\n".repeat(17_476_265) + "éx";
+    assert.strictEqual(Buffer.byteLength(stdout, "utf8"), 52_428_798);
+    const out = await runHook(hooksDir, root, {
+      session_id: "utf8-cap", tool_use_id: "utf8-cap",
+      tool_input: { command: "cat unicode.log" },
+      tool_response: { stdout, stderr: "same", interrupted: false, isImage: false },
+    });
+    const updated = JSON.parse(out).hookSpecificOutput.updatedToolOutput;
+    assert.ok(updated.stdout.includes("Full output preserved verbatim at .wolf/cache/bash/utf8-cap.log"));
+    const log = fs.readFileSync(path.join(root, ".wolf/cache/bash/utf8-cap.log"));
+    assert.strictEqual(log.byteLength, Buffer.byteLength(stdout, "utf8"));
+    assert.strictEqual(log.toString("utf8"), stdout);
+  });
+
+  for (const method of ["writeFileSync", "statSync", "unlinkSync"] as const) {
+    test(`issue #4: ${method} failure passes through and cleans current artifact`, async () => {
+      const { root, hooksDir } = setupProject();
+      if (method === "unlinkSync") {
+        const cacheDir = path.join(root, ".wolf", "cache", "bash");
+        fs.mkdirSync(cacheDir, { recursive: true });
+        for (let i = 0; i < 200; i++) fs.writeFileSync(path.join(cacheDir, `old-${i}.log`), "old");
+      }
+      const marker = path.join(root, `${method}.calls`);
+      const preload = faultPreload(root, method, marker);
+      const stdout = Array.from({ length: 900 }, (_, i) => `line ${i} with enough content to condense`).join("\n");
+      const response = { stdout, stderr: "failure stays", interrupted: false, isImage: false };
+      const out = await runHook(hooksDir, root, {
+        session_id: `fault-${method}`, tool_use_id: `fault-${method}`,
+        tool_input: { command: "cat failure.log" }, tool_response: response,
+      }, withPreload(preload, marker));
+      const parsed = JSON.parse(out || "{}");
+      assert.deepStrictEqual(parsed.hookSpecificOutput?.updatedToolOutput, undefined);
+      assert.ok(!out.includes("Full output preserved"));
+      assert.ok(!fs.existsSync(path.join(root, ".wolf/cache/bash", `fault-${method}.log`)));
+      const sessionPath = path.join(hooksDir, "sessions", `fault-${method}.json`);
+      const session = fs.existsSync(sessionPath) ? JSON.parse(fs.readFileSync(sessionPath, "utf8")) : {};
+      assert.deepStrictEqual(session.bash_governed ?? [], []);
+      assert.ok(fs.existsSync(marker));
+    });
+  }
+
+  test("issue #4: failed preservation leaves duplicate-read advice independent", async () => {
+    const { root, hooksDir } = setupProject();
+    const target = path.join(root, "repeat.md");
+    fs.writeFileSync(target, "hello world\n".repeat(50));
+    const content = fs.readFileSync(target, "utf8");
+    const first = await runHook(hooksDir, root, {
+      session_id: "fault-advice", tool_input: { command: `cat ${target}` },
+      tool_response: { stdout: content, stderr: "", interrupted: false, isImage: false },
+    });
+    assert.ok(!first.includes("already fully output"));
+    const marker = path.join(root, "advice-fault.calls");
+    const preload = faultPreload(root, "writeFileSync", marker);
+    const big = Array.from({ length: 900 }, (_, i) => `line ${i} with enough content to condense`).join("\n");
+    const out = await runHook(hooksDir, root, {
+      session_id: "fault-advice", tool_use_id: "fault-advice",
+      tool_input: { command: `cat ${target}` },
+      tool_response: { stdout: big, stderr: "", interrupted: false, isImage: false },
+    }, withPreload(preload, marker));
+    assert.ok(out.includes("already fully output"));
+    assert.ok(!out.includes("Full output preserved"));
+    assert.strictEqual(JSON.parse(out).hookSpecificOutput.updatedToolOutput, undefined);
   });
 
   test("bash read dedupe: second cat of an unchanged file gets a factual advisory", async () => {

--- a/tests/bash-governor.test.ts
+++ b/tests/bash-governor.test.ts
@@ -195,6 +195,21 @@ describe("post-bash compiled hook", { skip: !haveDist ? "dist not built" : false
     assert.strictEqual(quiet.trim(), "");
   });
 
+  test("issue #4: 50 MiB plus one byte is pass-through without a saved-copy claim", async () => {
+    const { root, hooksDir } = setupProject();
+    const stdout = "x\n".repeat(25 * 1024 * 1024) + "x";
+    const response = { stdout, stderr: "unchanged", interrupted: false, isImage: false };
+    const out = await runHook(hooksDir, root, {
+      session_id: "over-cap",
+      tool_use_id: "over-cap",
+      tool_input: { command: "cat big.log" },
+      tool_response: response,
+    });
+    const parsed = JSON.parse(out || "{}");
+    assert.strictEqual(parsed.hookSpecificOutput?.updatedToolOutput ?? response, response, "issue #4: over-cap output must pass through");
+    assert.ok(!out.includes("Full output preserved"));
+  });
+
   test("bash read dedupe: second cat of an unchanged file gets a factual advisory", async () => {
     const { root, hooksDir } = setupProject();
     const target = path.join(root, "notes.md");

--- a/tests/bash-governor.test.ts
+++ b/tests/bash-governor.test.ts
@@ -210,6 +210,32 @@ describe("post-bash compiled hook", { skip: !haveDist ? "dist not built" : false
     assert.ok(!out.includes("Full output preserved"));
   });
 
+  test("issue #4: exact 50 MiB is retained after evicting older logs", async () => {
+    const { root, hooksDir } = setupProject();
+    const cacheDir = path.join(root, ".wolf", "cache", "bash");
+    fs.mkdirSync(cacheDir, { recursive: true });
+    for (let i = 0; i < 200; i++) {
+      const old = path.join(cacheDir, `old-${String(i).padStart(3, "0")}.log`);
+      fs.writeFileSync(old, "old");
+      const when = new Date(1_000 + i * 1_000);
+      fs.utimesSync(old, when, when);
+    }
+    const stdout = "x\n".repeat(25 * 1024 * 1024);
+    const out = await runHook(hooksDir, root, {
+      session_id: "exact-cap", tool_use_id: "exact-cap",
+      tool_input: { command: "cat big.log" },
+      tool_response: { stdout, stderr: "same", interrupted: false, isImage: false },
+    });
+    const updated = JSON.parse(out).hookSpecificOutput.updatedToolOutput;
+    assert.ok(updated, "exact-cap output must be replaced only after retention");
+    const current = path.join(cacheDir, "exact-cap.log");
+    assert.strictEqual(fs.statSync(current).size, Buffer.byteLength(stdout, "utf8"));
+    const logs = fs.readdirSync(cacheDir).filter((f) => f.endsWith(".log"));
+    const bytes = logs.reduce((sum, f) => sum + fs.statSync(path.join(cacheDir, f)).size, 0);
+    assert.ok(logs.length <= 200 && bytes <= 50 * 1024 * 1024);
+    assert.ok(!fs.existsSync(path.join(cacheDir, "old-000.log")), "oldest log must be evicted");
+  });
+
   test("bash read dedupe: second cat of an unchanged file gets a factual advisory", async () => {
     const { root, hooksDir } = setupProject();
     const target = path.join(root, "notes.md");


### PR DESCRIPTION
## What

- gate Bash output replacement and saved-copy advice on verified complete cache retention
- protect the current log while evicting older logs until the existing 200-file and 50 MiB limits hold
- add compiled-hook regressions for exact/over-cap, multibyte, I/O failure, eviction-order, response-shape, accounting, and duplicate-read behavior

## Why

The governor could emit a recovery pointer and then delete that same log during pruning, making the original output irrecoverable.

Addresses cytostack/openwolf#82. Mirrors davdittrich/openwolf#4.

## How

One local retention result now authorizes all save-dependent recording and emission. It uses exact UTF-8 byte size, fails closed on filesystem errors, protects the current log, evicts oldest eligible logs, and verifies the final regular file and both cache limits.

## Verification

- `pnpm build:hooks`
- `node --test tests/bash-governor.test.ts` — 45 passed
- `pnpm test` — 233 passed
- `pnpm build`
- Claude review — PASS
- Antigravity review — PASS
