### PR TITLE
fix(scanner): publish freshness only after locked anatomy commit

### DIFF
--- a/src/hooks/anatomy-store.ts
+++ b/src/hooks/anatomy-store.ts
@@ -165,8 +165,11 @@ export function saveStore(wolfDir: string, store: AnatomyStoreData): void {
     fs.writeFileSync(tmp, body, "utf-8");
     fs.renameSync(tmp, filePath);
   } catch {
-    try { fs.writeFileSync(filePath, body, "utf-8"); } catch {}
-    try { fs.unlinkSync(tmp); } catch {}
+    try {
+      fs.writeFileSync(filePath, body, "utf-8");
+    } finally {
+      try { fs.unlinkSync(tmp); } catch {}
+    }
   }
 }
 
@@ -298,8 +301,11 @@ export function renderToFile(wolfDir: string, store: AnatomyStoreData): void {
     fs.writeFileSync(tmp, content, "utf-8");
     fs.renameSync(tmp, anatomyPath);
   } catch {
-    try { fs.writeFileSync(anatomyPath, content, "utf-8"); } catch {}
-    try { fs.unlinkSync(tmp); } catch {}
+    try {
+      fs.writeFileSync(anatomyPath, content, "utf-8");
+    } finally {
+      try { fs.unlinkSync(tmp); } catch {}
+    }
   }
 }
 

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -306,18 +306,17 @@ export async function scanProject(wolfDir: string, projectRoot: string): Promise
 
   const result = withAnatomyLock(wolfDir, CLI_LOCK_BUDGET_MS, () => {
     const existing = buildMergedStore(wolfDir, projectRoot, fresh);
-    existing.meta.lastScanned = new Date().toISOString();
+    const committedAt = new Date().toISOString();
+    existing.meta.lastScanned = committedAt;
     renderToFile(wolfDir, existing);
     saveStore(wolfDir, existing);
     // Record scan state so hooks can detect staleness (git switches, editor
     // edits outside an agent) without rescanning — Workstream F2b.
-    try {
-      writeJSON(path.join(wolfDir, "_scan-state.json"), {
-        last_scanned: new Date().toISOString(),
-        git_head: gitHead,
-        file_count: fileCount,
-      });
-    } catch {}
+    writeJSON(path.join(wolfDir, "_scan-state.json"), {
+      last_scanned: committedAt,
+      git_head: gitHead,
+      file_count: fileCount,
+    });
     return true;
   });
   if (result === null) {

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -299,6 +299,10 @@ export function buildMergedStore(
 
 export async function scanProject(wolfDir: string, projectRoot: string): Promise<number> {
   const { fileCount, store: fresh } = await buildAnatomy(wolfDir, projectRoot);
+  let gitHead: string | null = null;
+  try {
+    gitHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {}
 
   const result = withAnatomyLock(wolfDir, CLI_LOCK_BUDGET_MS, () => {
     const existing = buildMergedStore(wolfDir, projectRoot, fresh);
@@ -308,10 +312,6 @@ export async function scanProject(wolfDir: string, projectRoot: string): Promise
     // Record scan state so hooks can detect staleness (git switches, editor
     // edits outside an agent) without rescanning — Workstream F2b.
     try {
-      let gitHead: string | null = null;
-      try {
-        gitHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-      } catch {}
       writeJSON(path.join(wolfDir, "_scan-state.json"), {
         last_scanned: new Date().toISOString(),
         git_head: gitHead,

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -305,6 +305,19 @@ export async function scanProject(wolfDir: string, projectRoot: string): Promise
     existing.meta.lastScanned = new Date().toISOString();
     renderToFile(wolfDir, existing);
     saveStore(wolfDir, existing);
+    // Record scan state so hooks can detect staleness (git switches, editor
+    // edits outside an agent) without rescanning — Workstream F2b.
+    try {
+      let gitHead: string | null = null;
+      try {
+        gitHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+      } catch {}
+      writeJSON(path.join(wolfDir, "_scan-state.json"), {
+        last_scanned: new Date().toISOString(),
+        git_head: gitHead,
+        file_count: fileCount,
+      });
+    } catch {}
     return true;
   });
   if (result === null) {
@@ -314,20 +327,5 @@ export async function scanProject(wolfDir: string, projectRoot: string): Promise
     console.warn("  ! anatomy is being updated by another process; scan results not written (re-run to converge)");
   }
 
-  // Record scan state so hooks can detect staleness (git switches, editor
-  // edits outside an agent) without rescanning — Workstream F2b.
-  try {
-    let gitHead: string | null = null;
-    try {
-      gitHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-    } catch {}
-    writeJSON(path.join(wolfDir, "_scan-state.json"), {
-      last_scanned: new Date().toISOString(),
-      git_head: gitHead,
-      file_count: fileCount,
-    });
-  } catch {}
-
   return fileCount;
 }
-

--- a/src/utils/fs-safe.ts
+++ b/src/utils/fs-safe.ts
@@ -62,8 +62,11 @@ export function writeJSON(filePath: string, data: unknown): void {
   } catch {
     // On Windows, rename can fail if another process holds a handle.
     // Fall back to direct write and clean up the tmp file.
-    try { fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8"); } catch {}
-    try { fs.unlinkSync(tmp); } catch {}
+    try {
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+    } finally {
+      try { fs.unlinkSync(tmp); } catch {}
+    }
   }
 }
 

--- a/tests/anatomy-scanner.test.ts
+++ b/tests/anatomy-scanner.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { test } from "node:test";
+
+import { scanProject } from "../dist/src/scanner/anatomy-scanner.js";
+
+interface Fixture {
+  root: string;
+  wolfDir: string;
+  head: string;
+}
+
+function createFixture(): Fixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "wolf-scan-"));
+  const wolfDir = path.join(root, ".wolf");
+  fs.mkdirSync(path.join(root, "src"), { recursive: true });
+  fs.mkdirSync(wolfDir);
+  fs.writeFileSync(path.join(root, "src", "candidate.ts"), "export const candidate = 1;\n", "utf-8");
+  execFileSync("git", ["init", "--quiet"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "OpenWolf Test"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "openwolf-test@example.invalid"], { cwd: root });
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "--quiet", "-m", "fixture"], { cwd: root });
+  return {
+    root,
+    wolfDir,
+    head: execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf-8" }).trim(),
+  };
+}
+
+function holdLock(wolfDir: string): void {
+  fs.writeFileSync(
+    path.join(wolfDir, "anatomy-index.lock"),
+    JSON.stringify({ pid: process.pid, hostname: os.hostname(), acquiredAt: Date.now() }),
+    "utf-8"
+  );
+}
+
+function statePath(fixture: Fixture): string {
+  return path.join(fixture.wolfDir, "_scan-state.json");
+}
+
+test("scanProject publishes freshness only with a completed anatomy commit", async (t) => {
+  const absent = createFixture();
+  t.after(() => fs.rmSync(absent.root, { recursive: true, force: true }));
+  holdLock(absent.wolfDir);
+  const warn = t.mock.method(console, "warn", () => {});
+  const pending = scanProject(absent.wolfDir, absent.root);
+  assert.ok(pending instanceof Promise, "public scan remains Promise<number>");
+  const absentCount = await pending;
+  assert.strictEqual(typeof absentCount, "number");
+  assert.strictEqual(warn.mock.calls.length, 1);
+  assert.match(String(warn.mock.calls[0].arguments[0]), /anatomy is being updated/);
+  assert.ok(!fs.existsSync(path.join(absent.wolfDir, "anatomy.md")));
+  assert.ok(!fs.existsSync(path.join(absent.wolfDir, "anatomy-index.json")));
+  assert.ok(!fs.existsSync(statePath(absent)), "contention must not publish absent freshness");
+
+  const existing = createFixture();
+  t.after(() => fs.rmSync(existing.root, { recursive: true, force: true }));
+  const original = "{\"last_scanned\":\"before\"}\n";
+  fs.writeFileSync(statePath(existing), original, "utf-8");
+  const before = fs.statSync(statePath(existing), { bigint: true }).mtimeNs;
+  holdLock(existing.wolfDir);
+  await scanProject(existing.wolfDir, existing.root);
+  assert.strictEqual(fs.readFileSync(statePath(existing), "utf-8"), original);
+  assert.strictEqual(fs.statSync(statePath(existing), { bigint: true }).mtimeNs, before);
+
+  fs.unlinkSync(path.join(existing.wolfDir, "anatomy-index.lock"));
+  const count = await scanProject(existing.wolfDir, existing.root);
+  const store = JSON.parse(fs.readFileSync(path.join(existing.wolfDir, "anatomy-index.json"), "utf-8"));
+  const freshness = JSON.parse(fs.readFileSync(statePath(existing), "utf-8"));
+  assert.ok(fs.existsSync(path.join(existing.wolfDir, "anatomy.md")));
+  assert.strictEqual(freshness.git_head, existing.head);
+  assert.strictEqual(freshness.file_count, count);
+  assert.strictEqual(store.meta.fileCount, count);
+});
+
+test("scanProject does not advance freshness when saveStore fails", async (t) => {
+  const fixture = createFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+  const original = "{\"last_scanned\":\"before\"}\n";
+  fs.writeFileSync(statePath(fixture), original, "utf-8");
+  const before = fs.statSync(statePath(fixture), { bigint: true }).mtimeNs;
+  const toISOString = Date.prototype.toISOString;
+  t.mock.method(Date.prototype, "toISOString", function (this: Date): string {
+    if (new Error().stack?.includes("saveStore")) throw new Error("saveStore timestamp fault");
+    return toISOString.call(this);
+  });
+
+  await assert.rejects(scanProject(fixture.wolfDir, fixture.root), /saveStore timestamp fault/);
+  assert.strictEqual(fs.readFileSync(statePath(fixture), "utf-8"), original);
+  assert.strictEqual(fs.statSync(statePath(fixture), { bigint: true }).mtimeNs, before);
+});

--- a/tests/anatomy-scanner.test.ts
+++ b/tests/anatomy-scanner.test.ts
@@ -78,19 +78,28 @@ test("scanProject publishes freshness only with a completed anatomy commit", asy
   assert.strictEqual(store.meta.fileCount, count);
 });
 
-test("scanProject does not advance freshness when saveStore fails", async (t) => {
+test("scanProject does not advance freshness when render fallback fails", async (t) => {
   const fixture = createFixture();
   t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
   const original = "{\"last_scanned\":\"before\"}\n";
   fs.writeFileSync(statePath(fixture), original, "utf-8");
   const before = fs.statSync(statePath(fixture), { bigint: true }).mtimeNs;
-  const toISOString = Date.prototype.toISOString;
-  t.mock.method(Date.prototype, "toISOString", function (this: Date): string {
-    if (new Error().stack?.includes("saveStore")) throw new Error("saveStore timestamp fault");
-    return toISOString.call(this);
-  });
+  fs.mkdirSync(path.join(fixture.wolfDir, "anatomy.md"));
 
-  await assert.rejects(scanProject(fixture.wolfDir, fixture.root), /saveStore timestamp fault/);
+  await assert.rejects(scanProject(fixture.wolfDir, fixture.root));
+  assert.strictEqual(fs.readFileSync(statePath(fixture), "utf-8"), original);
+  assert.strictEqual(fs.statSync(statePath(fixture), { bigint: true }).mtimeNs, before);
+});
+
+test("scanProject does not advance freshness when store fallback fails", async (t) => {
+  const fixture = createFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+  const original = "{\"last_scanned\":\"before\"}\n";
+  fs.writeFileSync(statePath(fixture), original, "utf-8");
+  const before = fs.statSync(statePath(fixture), { bigint: true }).mtimeNs;
+  fs.mkdirSync(path.join(fixture.wolfDir, "anatomy-index.json"));
+
+  await assert.rejects(scanProject(fixture.wolfDir, fixture.root));
   assert.strictEqual(fs.readFileSync(statePath(fixture), "utf-8"), original);
   assert.strictEqual(fs.statSync(statePath(fixture), { bigint: true }).mtimeNs, before);
 });

--- a/tests/anatomy-scanner.test.ts
+++ b/tests/anatomy-scanner.test.ts
@@ -73,6 +73,7 @@ test("scanProject publishes freshness only with a completed anatomy commit", asy
   const store = JSON.parse(fs.readFileSync(path.join(existing.wolfDir, "anatomy-index.json"), "utf-8"));
   const freshness = JSON.parse(fs.readFileSync(statePath(existing), "utf-8"));
   assert.ok(fs.existsSync(path.join(existing.wolfDir, "anatomy.md")));
+  assert.strictEqual(freshness.last_scanned, store.meta.lastScanned);
   assert.strictEqual(freshness.git_head, existing.head);
   assert.strictEqual(freshness.file_count, count);
   assert.strictEqual(store.meta.fileCount, count);
@@ -102,4 +103,12 @@ test("scanProject does not advance freshness when store fallback fails", async (
   await assert.rejects(scanProject(fixture.wolfDir, fixture.root));
   assert.strictEqual(fs.readFileSync(statePath(fixture), "utf-8"), original);
   assert.strictEqual(fs.statSync(statePath(fixture), { bigint: true }).mtimeNs, before);
+});
+
+test("scanProject rejects when freshness fallback fails", async (t) => {
+  const fixture = createFixture();
+  t.after(() => fs.rmSync(fixture.root, { recursive: true, force: true }));
+  fs.mkdirSync(statePath(fixture));
+
+  await assert.rejects(scanProject(fixture.wolfDir, fixture.root));
 });


### PR DESCRIPTION
## Summary

- publish `_scan-state.json` only after anatomy render and durable store persistence under the same lock
- propagate terminal render, store, and freshness persistence failures
- use one commit timestamp for the durable store and freshness marker
- cover lock contention and all terminal failure paths through public `scanProject` tests

## Verification

- focused scanner regressions: 4/4 passed
- complete post-build suite: 209/209 passed
- production build passed
- Antigravity review: PASS
- Claude review: PASS

Closes #85.

Fork mirror: davdittrich/openwolf#3.