### PR TITLE
2.6.0: multi-writer safety for shared .wolf + opt-in extra_roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,17 @@ untrue.
 
 ## [Unreleased]
 
+### Added
+
+- `openwolf.anatomy.extra_roots` (opt-in, default `[]`): sibling directories
+  outside the project root to index alongside it, under `../sibling/...`
+  keys. 2.5.0's "never index outside the project root" rule conflated kind
+  (scratch/temp noise) with location — it also evicted a sibling repo one
+  real project works in daily, so `find` could no longer see that code.
+  The write-tracking hook honors the same list; scratch dirs stay excluded;
+  the `max_files` budget is shared with the project's own files, which are
+  scanned first.
+
 ### Fixed
 
 - Multi-writer safety for sessions sharing one `.wolf` (TIK-System field
@@ -106,6 +117,10 @@ untrue.
   `venv`, `site-packages`, `__pycache__`, `.tox`, `node_modules`) regardless
   of `exclude_patterns`: projects with a customized exclude list keep it on
   update, which let a scan fill 55% of one real index with virtualenv files.
+  Worse than noise: under the `max_files` cap (500 by default) those entries
+  *displace* real source — the same project indexed 283 venv files against a
+  516-file cap-bound scan, and 552 real files once excluded — so the symptom
+  is `find` silently missing your own code, not a visibly noisy index.
 
 ## [2.4.1] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,26 @@ untrue.
 - Hook count corrected to 12 everywhere. The docs said 10 while documenting
   12.
 
+## [Unreleased]
+
+### Fixed
+
+- Multi-writer safety for sessions sharing one `.wolf` (TIK-System field
+  report): buglog writes are now serialized through `buglog.json.lock` (the
+  CLI falls back to an unlocked write on lock timeout so a user-requested log
+  is never dropped; the auto-detect hook skips on contention), the
+  `total_sessions` increment reuses the token-ledger lock, and the auto-detect
+  hook assigns bug ids from the max existing id instead of the array length,
+  which collided under concurrent writers.
+- The session digest now warns when other sessions are active on the same
+  `.wolf` (sibling state files under `hooks/sessions/` touched within 30
+  minutes), and `/handoff` archives the previous `STATUS.md` to
+  `.wolf/plans/` before rewriting so a concurrent regeneration costs nothing.
+- The anatomy scanner hard-excludes vendored language environments (`.venv`,
+  `venv`, `site-packages`, `__pycache__`, `.tox`, `node_modules`) regardless
+  of `exclude_patterns`: projects with a customized exclude list keep it on
+  update, which let a scan fill 55% of one real index with virtualenv files.
+
 ## [2.4.1] - 2026-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ untrue.
 - Hook count corrected to 12 everywhere. The docs said 10 while documenting
   12.
 
-## [Unreleased]
+## [2.6.0] - 2026-08-26
 
 ### Added
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,10 +84,20 @@ The project scanner.
 | `max_description_length` | `100` | Max characters per file description |
 | `max_files` | `500` | Stop scanning after this many files |
 | `exclude_patterns` | node_modules, .git, dist, ... | Directories and globs to skip |
+| `extra_roots` | `[]` | Sibling directories outside the project root to index as well, e.g. `["../mac-os-native"]` |
 
-Lockfiles, OS junk, caches, coverage, minified files, and agent-config
+Lockfiles, OS junk, caches, coverage, minified files, vendored language
+environments (`.venv`, `site-packages`, and friends), and agent-config
 directories (`.claude`, `.codex`, and friends) are excluded built-in,
 regardless of this list.
+
+`extra_roots` is for a repo you work in daily that has no `.wolf` of its own —
+a sibling client or service of the same product. Its files are indexed under
+`../sibling/...` keys, so `openwolf find` covers them from this project, and
+the write-tracking hooks keep their entries fresh. Everything else outside the
+project root (scratch dirs, temp files) stays excluded. The `max_files` budget
+is shared, and the project's own files are scanned first, so an extra root can
+never displace them.
 
 ## `token_audit`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwolf",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "One project memory across Claude Code, Codex and OpenCode. Token usage measured, not estimated. Zero API calls.",
   "type": "module",
   "bin": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true

--- a/src/buglog/bug-tracker.ts
+++ b/src/buglog/bug-tracker.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import { readJSON, writeJSON } from "../utils/fs-safe.js";
+import { withFileLock, CLI_LOCK_BUDGET_MS } from "../hooks/anatomy-lock.js";
 
 interface BugEntry {
   id: string;
@@ -41,6 +42,28 @@ export function readBugLog(wolfDir: string): BugLog {
 }
 
 export function logBug(
+  wolfDir: string,
+  bug: {
+    error_message: string;
+    file: string;
+    line?: number;
+    root_cause: string;
+    fix: string;
+    tags: string[];
+  }
+): void {
+  // Locked read-modify-write: two sessions sharing one .wolf logged bugs
+  // concurrently and the second write clobbered the first (TIK-System field
+  // report). On lock timeout we fall back to the unlocked path — a
+  // user-requested bug log must never be silently dropped.
+  const locked = withFileLock(getBugLogPath(wolfDir) + ".lock", CLI_LOCK_BUDGET_MS, () => {
+    logBugUnlocked(wolfDir, bug);
+    return true;
+  });
+  if (!locked) logBugUnlocked(wolfDir, bug);
+}
+
+function logBugUnlocked(
   wolfDir: string,
   bug: {
     error_message: string;

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -423,7 +423,7 @@ function generateTemplate(destPath: string, file: string): void {
       version: 1,
       openwolf: {
         enabled: true,
-        anatomy: { auto_scan_on_init: true, rescan_interval_hours: 6, max_description_length: 100, max_files: 500, exclude_patterns: ["node_modules", ".git", "dist", "build", ".wolf", ".next", ".nuxt", "coverage", "__pycache__", ".cache", "target", ".vscode", ".idea", ".turbo", ".vercel", ".netlify", ".output", "*.min.js", "*.min.css"] },
+        anatomy: { auto_scan_on_init: true, rescan_interval_hours: 6, max_description_length: 100, max_files: 500, exclude_patterns: ["node_modules", ".git", "dist", "build", ".wolf", ".next", ".nuxt", "coverage", "__pycache__", ".cache", "target", ".vscode", ".idea", ".turbo", ".vercel", ".netlify", ".output", "*.min.js", "*.min.css", ".venv", "venv", "site-packages", ".tox"], extra_roots: [] },
         token_audit: { enabled: true, report_frequency: "weekly", waste_threshold_percent: 15, chars_per_token_code: 3.5, chars_per_token_prose: 4.0 },
         cron: { enabled: true, max_retry_attempts: 3, dead_letter_enabled: true, heartbeat_interval_minutes: 30 },
         memory: { consolidation_after_days: 7, max_entries_before_consolidation: 200 },

--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -7,7 +7,7 @@ import {
   isSensitiveFile, getProjectDir, emitHookJSON, recordInjection, hookMain, getSessionFilePath
 } from "./shared.js";
 import { loadStoreReconciled, saveStore, renderToFile, sha256 } from "./anatomy-store.js";
-import { withAnatomyLock, HOOK_LOCK_BUDGET_MS } from "./anatomy-lock.js";
+import { withAnatomyLock, withFileLock, HOOK_LOCK_BUDGET_MS } from "./anatomy-lock.js";
 import { extractSymbols, symbolsSupported, SYMBOL_MIN_TOKENS } from "./symbol-extractor.js";
 
 // File types where a value/string change is normal content editing, not a bug
@@ -365,50 +365,63 @@ function autoDetectBugFix(wolfDir: string, absolutePath: string, projectRoot: st
   // Respect an explicit opt-out in .wolf/config.json (default: enabled).
   if (!bugAutoDetectEnabled(wolfDir)) return;
 
-  const bugLogPath = path.join(wolfDir, "buglog.json");
-  const bugLog = readBugLogFile(wolfDir) as BugLog;
-  const relFile = normalizePath(path.relative(projectRoot, absolutePath));
-
   // Detect what kind of fix this is
   const detection = detectFixPattern(oldStr, newStr, ext, basename);
   if (!detection) return;
 
-  // Check for recent duplicate (same file + same category within 5 min)
-  const recentDupe = bugLog.bugs.find(b => {
-    if (path.basename(b.file) !== basename) return false;
-    if (!b.tags.includes("auto-detected")) return false;
-    if (!b.tags.includes(detection.category)) return false;
-    const bugTime = new Date(b.last_seen).getTime();
-    return (Date.now() - bugTime) < 5 * 60 * 1000;
-  });
+  const bugLogPath = path.join(wolfDir, "buglog.json");
+  const relFile = normalizePath(path.relative(projectRoot, absolutePath));
 
-  if (recentDupe) {
-    recentDupe.occurrences++;
-    recentDupe.last_seen = new Date().toISOString();
-    // Append additional context
-    if (detection.context && !recentDupe.fix.includes(detection.context)) {
-      recentDupe.fix += ` | Also: ${detection.context}`;
+  // Locked read-modify-write: concurrent sessions share buglog.json and an
+  // unlocked interleave loses entries. On contention we skip — auto-detection
+  // is best-effort and the next qualifying edit fires again.
+  withFileLock(bugLogPath + ".lock", HOOK_LOCK_BUDGET_MS, () => {
+    const bugLog = readBugLogFile(wolfDir) as BugLog;
+
+    // Check for recent duplicate (same file + same category within 5 min)
+    const recentDupe = bugLog.bugs.find(b => {
+      if (path.basename(b.file ?? "") !== basename) return false;
+      if (!b.tags.includes("auto-detected")) return false;
+      if (!b.tags.includes(detection.category)) return false;
+      const bugTime = new Date(b.last_seen).getTime();
+      return (Date.now() - bugTime) < 5 * 60 * 1000;
+    });
+
+    if (recentDupe) {
+      recentDupe.occurrences++;
+      recentDupe.last_seen = new Date().toISOString();
+      // Append additional context
+      if (detection.context && !recentDupe.fix.includes(detection.context)) {
+        recentDupe.fix += ` | Also: ${detection.context}`;
+      }
+      writeJSON(bugLogPath, bugLog);
+      return;
     }
+
+    // Next id from the max existing numeric id, not the array length — same
+    // rule as bug-tracker.ts: deletions and concurrent writers made
+    // length-based ids collide.
+    const maxId = bugLog.bugs.reduce((max, b) => {
+      const n = parseInt(String(b.id ?? "").replace(/^bug-/, ""), 10);
+      return Number.isFinite(n) && n > max ? n : max;
+    }, 0);
+    const nextId = `bug-${String(maxId + 1).padStart(3, "0")}`;
+
+    bugLog.bugs.push({
+      id: nextId,
+      timestamp: new Date().toISOString(),
+      error_message: detection.summary,
+      file: relFile,
+      root_cause: detection.rootCause,
+      fix: detection.fix,
+      tags: ["auto-detected", detection.category, ext.replace(".", "") || "unknown"],
+      related_bugs: [],
+      occurrences: 1,
+      last_seen: new Date().toISOString(),
+    });
+
     writeJSON(bugLogPath, bugLog);
-    return;
-  }
-
-  const nextId = `bug-${String(bugLog.bugs.length + 1).padStart(3, "0")}`;
-
-  bugLog.bugs.push({
-    id: nextId,
-    timestamp: new Date().toISOString(),
-    error_message: detection.summary,
-    file: relFile,
-    root_cause: detection.rootCause,
-    fix: detection.fix,
-    tags: ["auto-detected", detection.category, ext.replace(".", "") || "unknown"],
-    related_bugs: [],
-    occurrences: 1,
-    last_seen: new Date().toISOString(),
   });
-
-  writeJSON(bugLogPath, bugLog);
 }
 
 interface FixDetection {

--- a/src/hooks/post-write.ts
+++ b/src/hooks/post-write.ts
@@ -98,7 +98,12 @@ async function main(): Promise<void> {
   // Never track files outside the project root (e.g. the Claude Code scratchpad under
   // /private/tmp). path.relative() yields ../.. section keys that pollute anatomy.md and are
   // wiped again by every full `openwolf scan`, so the index churns instead of converging.
-  if (relPath.startsWith("..") || path.isAbsolute(relPath)) { return; }
+  // Exception: paths under a configured `extra_roots` sibling — the scan
+  // indexes those under the same `../sibling/...` keys, so tracking them
+  // here converges instead of churning.
+  if (relPath.startsWith("..") || path.isAbsolute(relPath)) {
+    if (!isWithinExtraRoots(wolfDir, projectRoot, absolutePath)) { return; }
+  }
 
   // Never track secret-bearing files in anatomy/memory (issue #54): .env is
   // not the only file whose *description* would leak sensitive content.
@@ -339,6 +344,30 @@ function extractCalls(code: string): string[] {
       .map(m => m.match(/(\w+)/)?.[1] || "")
       .filter(n => n.length > 2 && !["if", "for", "while", "switch", "catch", "function", "return", "new", "typeof", "instanceof", "const", "let", "var"].includes(n))
   )];
+}
+
+/**
+ * True when `absolutePath` sits inside one of the opt-in sibling roots
+ * declared in `.wolf/config.json` (`openwolf.anatomy.extra_roots`). Mirrors
+ * the scan-side rule in src/scanner/anatomy-scanner.ts — hooks are standalone
+ * scripts and cannot import from the scanner build.
+ */
+function isWithinExtraRoots(wolfDir: string, projectRoot: string, absolutePath: string): boolean {
+  try {
+    const cfg = readJSON<{ openwolf?: { anatomy?: { extra_roots?: string[] } } }>(
+      path.join(wolfDir, "config.json"),
+      {}
+    );
+    const roots = cfg.openwolf?.anatomy?.extra_roots;
+    if (!Array.isArray(roots)) return false;
+    const target = path.resolve(absolutePath);
+    for (const r of roots) {
+      if (typeof r !== "string" || r.trim() === "") continue;
+      const absRoot = path.resolve(projectRoot, r);
+      if (target === absRoot || target.startsWith(absRoot + path.sep)) return true;
+    }
+  } catch {}
+  return false;
 }
 
 // ─── Auto Bug Detection ──────────────────────────────────────────

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { getWolfDir, ensureWolfDir, writeJSON, appendMarkdown, readJSON, readBugLogFile, timestamp, timeShort, estimateTokens, readStdin, detectAgent, recordInjectionToSessionFile, getProjectDir, hookMain, getSessionFilePath, gcSessionFiles } from "./shared.js";
 import { loadStore } from "./anatomy-store.js";
+import { withFileLock, HOOK_LOCK_BUDGET_MS } from "./anatomy-lock.js";
 import { topRules, scopedRulesForFiles } from "./rule-reinjection.js";
 
 // ─── Session digest (Workstream E/F: model-aware context budgeting) ─────────
@@ -14,6 +15,31 @@ import { topRules, scopedRulesForFiles } from "./rule-reinjection.js";
 interface ContextConfig {
   session_digest_budget_tokens?: number;
   budgets?: Record<string, number>;
+}
+
+// A sibling session file touched within this window means another agent is
+// live on the same .wolf right now (per-session state files are upserted
+// every turn by the Stop hook).
+const ACTIVE_SESSION_WINDOW_MS = 30 * 60 * 1000;
+
+/** Count other sessions' state files recently touched under hooks/sessions/. */
+function countOtherActiveSessions(wolfDir: string, ownSessionFile: string): number {
+  try {
+    const dir = path.join(wolfDir, "hooks", "sessions");
+    const own = path.resolve(ownSessionFile);
+    let n = 0;
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith(".json")) continue;
+      const full = path.join(dir, f);
+      if (path.resolve(full) === own) continue;
+      try {
+        if (Date.now() - fs.statSync(full).mtimeMs < ACTIVE_SESSION_WINDOW_MS) n++;
+      } catch {}
+    }
+    return n;
+  } catch {
+    return 0;
+  }
 }
 
 function digestBudget(wolfDir: string): number {
@@ -278,13 +304,19 @@ async function main(): Promise<void> {
   // counted, which used to inflate the lifetime count.
   if (!continuing) {
     const ledgerPath = path.join(wolfDir, "token-ledger.json");
-    const ledger = readJSON(ledgerPath, { version: 1, lifetime: { total_sessions: 0 } }) as {
-      version: number;
-      lifetime: { total_sessions: number };
-      [key: string]: unknown;
-    };
-    ledger.lifetime.total_sessions++;
-    writeJSON(ledgerPath, ledger);
+    // Same lock as flushSessionToLedger: two sessions starting at once on a
+    // shared .wolf interleave this read-modify-write and lose an increment
+    // (or worse, clobber a concurrent Stop flush). On contention, skip — an
+    // undercounted lifetime total is cheaper than a corrupted ledger.
+    withFileLock(ledgerPath + ".lock", HOOK_LOCK_BUDGET_MS, () => {
+      const ledger = readJSON(ledgerPath, { version: 1, lifetime: { total_sessions: 0 } }) as {
+        version: number;
+        lifetime: { total_sessions: number };
+        [key: string]: unknown;
+      };
+      ledger.lifetime.total_sessions++;
+      writeJSON(ledgerPath, ledger);
+    });
   }
 
   // Inject the budget-capped digest into the model's context.
@@ -300,6 +332,15 @@ async function main(): Promise<void> {
     // install silently loses every feature (happened for 3 weeks once).
     if (brokenHooks.length > 0) {
       digest = `OpenWolf hooks are degraded: ${brokenHooks.join("; ")}. Run \`openwolf update\` in this project to repair the install.\n\n` + digest;
+    }
+
+    // Multi-writer awareness (TIK-System field report): two sessions sharing
+    // one .wolf overwrote each other's STATUS.md and plan files without
+    // either knowing the other existed. Appends and locked JSON writes are
+    // safe; whole-file rewrites are the hazard worth a warning.
+    const otherSessions = countOtherActiveSessions(wolfDir, sessionFile);
+    if (otherSessions > 0) {
+      digest = `${otherSessions} other active session(s) share this project's .wolf. Log appends (memory, buglog) are concurrency-safe, but whole-file rewrites are not: before regenerating .wolf/STATUS.md or writing shared plan files, coordinate via ListAgents/SendMessage, and prefer per-session plan files under .wolf/plans/.\n\n` + digest;
     }
 
     // Post-compaction restore (F3 + 2.4): resurface what compaction erased.

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -20,6 +20,7 @@ interface WolfConfig {
       max_description_length: number;
       max_files: number;
       exclude_patterns: string[];
+      extra_roots?: string[];
     };
     token_audit: {
       chars_per_token_code: number;
@@ -236,6 +237,34 @@ export async function buildAnatomy(wolfDir: string, projectRoot: string): Promis
     store.files,
     contents
   );
+
+  // Opt-in sibling roots (`extra_roots` in config): "never index outside the
+  // project root" is about scratch/temp locations, but a sibling repo the
+  // user works in daily is a legitimate target — the TIK-System index lost
+  // its entire macOS client when 2.5.0 dropped out-of-root paths (kind vs
+  // location: the rule conflated them). Entries are resolved against the
+  // project root and indexed under their `../sibling/...` keys; roots inside
+  // the project are skipped (the main walk covered them), and the max_files
+  // budget is shared across all roots so extras can't displace own-project
+  // files that were walked first.
+  for (const extra of config.openwolf.anatomy.extra_roots ?? []) {
+    if (typeof extra !== "string" || extra.trim() === "") continue;
+    const absRoot = path.resolve(projectRoot, extra);
+    if (!path.relative(projectRoot, absRoot).startsWith("..")) continue;
+    try {
+      if (!fs.statSync(absRoot).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    walkDir(
+      absRoot,
+      projectRoot,
+      config.openwolf.anatomy.exclude_patterns,
+      config.openwolf.anatomy.max_files,
+      store.files,
+      contents
+    );
+  }
 
   // J2: upgrade regex symbols to exact tree-sitter results where a grammar is
   // available, and emit a signature skeleton for large files. Failure of the

--- a/src/scanner/anatomy-scanner.ts
+++ b/src/scanner/anatomy-scanner.ts
@@ -65,6 +65,11 @@ const NOISE_DIRS = new Set([
   // via the index is noise (audit: .claude/*.md topped a project's importance
   // ranking), and the agent already knows these files natively.
   ".claude", ".codex", ".opencode", ".gemini", ".cursor", ".agents",
+  // Vendored language environments: hard-excluded here (not just in the
+  // config defaults) because existing projects keep their customized
+  // exclude_patterns on update — a TIK-System scan indexed 283 .venv files
+  // (55% of the index) through exactly that gap.
+  ".venv", "venv", "site-packages", "__pycache__", ".tox", "node_modules",
 ]);
 
 function isNoiseFile(relPath: string): boolean {

--- a/src/templates/config.json
+++ b/src/templates/config.json
@@ -45,8 +45,13 @@
         ".netlify",
         ".output",
         "*.min.js",
-        "*.min.css"
-      ]
+        "*.min.css",
+        ".venv",
+        "venv",
+        "site-packages",
+        ".tox"
+      ],
+      "extra_roots": []
     },
     "token_audit": {
       "enabled": true,

--- a/src/templates/skills/handoff.md
+++ b/src/templates/skills/handoff.md
@@ -5,6 +5,7 @@ Build it from the session's actual state, not from memory of the conversation al
 1. Read the current `.wolf/STATUS.md` to preserve its structure and any still-relevant open items.
 2. Run `git status --short` and `git log --oneline -8` to see what actually changed.
 3. Skim the latest session block of `.wolf/memory.md` for the action log.
+4. Archive the current file before rewriting: copy `.wolf/STATUS.md` to `.wolf/plans/STATUS-<YYYY-MM-DD-HHMM>.md` (create `plans/` if needed). STATUS.md is a whole-file rewrite, and when several sessions share one `.wolf` a concurrent regeneration silently clobbers the other session's handoff — the archive makes that overwrite cost nothing. If the session digest warned that other sessions are active, mention their work in `## Context` rather than merging guesses about it.
 
 Then rewrite `.wolf/STATUS.md` with:
 

--- a/tests/buglog-concurrency.test.ts
+++ b/tests/buglog-concurrency.test.ts
@@ -1,0 +1,65 @@
+import { test, describe } from "node:test";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// bug-tracker.ts imports ../hooks/anatomy-lock.js, and node's type stripping
+// does not map a .js specifier onto its .ts source, so this exercises the
+// build output the way buglog-shape.test.ts does.
+const DIST = path.resolve(import.meta.dirname ?? ".", "..", "dist", "src", "buglog", "bug-tracker.js");
+const tracker: {
+  logBug: (d: string, b: Record<string, unknown>) => void;
+  readBugLog: (d: string) => { bugs: Array<{ id: string; error_message: string; occurrences: number }> };
+} | null = fs.existsSync(DIST) ? await import(DIST) : null;
+
+function tmpWolf(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "wolf-blc-"));
+  const wolfDir = path.join(root, ".wolf");
+  fs.mkdirSync(wolfDir, { recursive: true });
+  return wolfDir;
+}
+
+function bug(msg: string) {
+  return { error_message: msg, file: "src/a.ts", root_cause: "r", fix: "f", tags: ["t"] };
+}
+
+// Multi-writer regression (TIK-System field report): two sessions sharing one
+// .wolf logged bugs concurrently and the second read-modify-write clobbered
+// the first. logBug now serializes through buglog.json.lock.
+describe("buglog multi-writer", { skip: tracker === null && "dist build missing" }, () => {
+  test("sequential logs assign distinct max-based ids and lose nothing", () => {
+    const wolfDir = tmpWolf();
+    tracker!.logBug(wolfDir, bug("first distinct failure alpha"));
+    tracker!.logBug(wolfDir, bug("second distinct failure beta"));
+    const log = tracker!.readBugLog(wolfDir);
+    assert.equal(log.bugs.length, 2);
+    assert.deepEqual(log.bugs.map((b) => b.id), ["bug-001", "bug-002"]);
+  });
+
+  test("a stale foreign lock does not drop a user-requested log", () => {
+    const wolfDir = tmpWolf();
+    // A lock owned by a dead pid on this host is stale and must be stolen
+    // (or, at worst, fall back to the unlocked write) — never a silent drop.
+    fs.writeFileSync(
+      path.join(wolfDir, "buglog.json.lock"),
+      JSON.stringify({ pid: 999999999, hostname: os.hostname(), acquiredAt: Date.now() - 60_000 }),
+      "utf-8"
+    );
+    tracker!.logBug(wolfDir, bug("logged despite stale lock"));
+    const log = tracker!.readBugLog(wolfDir);
+    assert.equal(log.bugs.length, 1);
+    assert.equal(log.bugs[0].error_message, "logged despite stale lock");
+  });
+
+  test("lock is released after logging (second log proceeds immediately)", () => {
+    const wolfDir = tmpWolf();
+    tracker!.logBug(wolfDir, bug("first distinct failure alpha"));
+    assert.equal(fs.existsSync(path.join(wolfDir, "buglog.json.lock")), false);
+    const start = Date.now();
+    tracker!.logBug(wolfDir, bug("second distinct failure beta"));
+    // No lock contention: must not burn the 5s CLI budget.
+    assert.ok(Date.now() - start < 1000);
+    assert.equal(tracker!.readBugLog(wolfDir).bugs.length, 2);
+  });
+});

--- a/tests/extra-roots.test.ts
+++ b/tests/extra-roots.test.ts
@@ -1,0 +1,68 @@
+import { test, describe } from "node:test";
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// anatomy-scanner.ts imports with .js specifiers, and node's type stripping
+// does not map those onto .ts sources, so this exercises the build output the
+// way buglog-shape.test.ts does.
+const DIST = path.resolve(import.meta.dirname ?? ".", "..", "dist", "src", "scanner", "anatomy-scanner.js");
+const scanner: {
+  buildAnatomy: (wolfDir: string, projectRoot: string) => Promise<{ fileCount: number; store: { files: Record<string, unknown> } }>;
+} | null = fs.existsSync(DIST) ? await import(DIST) : null;
+
+function setup(extraRoots: string[] | undefined): { wolfDir: string; projectRoot: string } {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "wolf-xr-"));
+  const projectRoot = path.join(base, "project");
+  const wolfDir = path.join(projectRoot, ".wolf");
+  fs.mkdirSync(path.join(projectRoot, "src"), { recursive: true });
+  fs.mkdirSync(wolfDir, { recursive: true });
+  fs.writeFileSync(path.join(projectRoot, "src", "own.ts"), "export const own = 1;\n");
+
+  const sibling = path.join(base, "sibling");
+  fs.mkdirSync(path.join(sibling, "ui"), { recursive: true });
+  fs.mkdirSync(path.join(sibling, ".venv", "lib"), { recursive: true });
+  fs.writeFileSync(path.join(sibling, "ui", "View.swift"), "struct View {}\n");
+  fs.writeFileSync(path.join(sibling, ".venv", "lib", "pkg.py"), "x = 1\n");
+
+  if (extraRoots !== undefined) {
+    fs.writeFileSync(
+      path.join(wolfDir, "config.json"),
+      JSON.stringify({ version: 1, openwolf: { anatomy: { max_description_length: 100, max_files: 500, exclude_patterns: ["node_modules", ".git", ".wolf"], extra_roots: extraRoots }, token_audit: { chars_per_token_code: 3.5, chars_per_token_prose: 4.0 } } }),
+      "utf-8"
+    );
+  }
+  return { wolfDir, projectRoot };
+}
+
+describe("extra_roots", { skip: scanner === null && "dist build missing" }, () => {
+  test("out-of-root paths stay excluded by default", async () => {
+    const { wolfDir, projectRoot } = setup(undefined);
+    const { store } = await scanner!.buildAnatomy(wolfDir, projectRoot);
+    const keys = Object.keys(store.files);
+    assert.ok(keys.includes("src/own.ts"));
+    assert.ok(!keys.some((k) => k.startsWith("..")), `unexpected out-of-root keys: ${keys}`);
+  });
+
+  test("a configured sibling root is indexed under ../ keys", async () => {
+    const { wolfDir, projectRoot } = setup(["../sibling"]);
+    const { store } = await scanner!.buildAnatomy(wolfDir, projectRoot);
+    const keys = Object.keys(store.files);
+    assert.ok(keys.includes("src/own.ts"));
+    assert.ok(keys.includes("../sibling/ui/View.swift"), `missing sibling file, got: ${keys}`);
+  });
+
+  test("noise dirs are still hard-excluded inside an extra root", async () => {
+    const { wolfDir, projectRoot } = setup(["../sibling"]);
+    const { store } = await scanner!.buildAnatomy(wolfDir, projectRoot);
+    assert.ok(!Object.keys(store.files).some((k) => k.includes(".venv")));
+  });
+
+  test("an extra root inside the project, a missing dir, and junk entries are ignored", async () => {
+    const { wolfDir, projectRoot } = setup(["src", "../does-not-exist", "", 42 as unknown as string]);
+    const { store } = await scanner!.buildAnatomy(wolfDir, projectRoot);
+    const keys = Object.keys(store.files);
+    assert.deepEqual(keys, ["src/own.ts"]);
+  });
+});


### PR DESCRIPTION
Two field-reported problems from a real two-session project (TIK-System), fixed and released together as 2.6.0.

## Multi-writer safety (sessions sharing one .wolf)

- Serialize buglog.json writes through a lockfile in both the CLI logger and the post-write auto-detect hook. The CLI falls back to an unlocked write on lock timeout so a user-requested log is never dropped; the hook skips on contention.
- Fix the auto-detect hook's length-based bug ids (collided under concurrent writers and after deletions) — now max-id, same as bug-tracker.
- Reuse the token-ledger lock for the session-start total_sessions increment.
- Session digest now warns when sibling session files were touched within 30 minutes, so sessions sharing a .wolf know about each other.
- /handoff archives the outgoing STATUS.md to .wolf/plans/ before rewriting, so a concurrent regeneration costs nothing.

## anatomy: venv displacement + extra_roots

- Hard-exclude vendored language environments (.venv, venv, site-packages, __pycache__, .tox, node_modules) regardless of exclude_patterns: customized exclude lists are preserved on update, which let a scan fill 55% of a real index with virtualenv files. Under the max_files cap those entries displace real source — the symptom is `find` silently missing your own code, not visible noise.
- New opt-in `openwolf.anatomy.extra_roots` (default `[]`): sibling directories outside the project root indexed under `../sibling/...` keys. 2.5.0's out-of-root exclusion conflated kind (scratch noise) with location and evicted a sibling repo worked in daily. Shared max_files budget, own-project files walked first, noise dirs still excluded, post-write honors the same list.

## Tests

7 new tests (buglog concurrency, extra_roots); full suite 212/212 green; verified end-to-end via local tarball install (`npm pack`) rolled to 39 registered projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXfNQaMwh55k5w1PG2a9EJ