### PR TITLE
fix: restrict daemon control to owned PM2 process

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -161,10 +161,13 @@ PM2 required. Each project gets its own port and token.
 
 ```bash
 openwolf daemon start     # persistent daemon via PM2
-openwolf daemon stop      # stops PM2 or forked daemons alike
-openwolf daemon restart
+openwolf daemon stop      # stop this project's exact PM2 registration
+openwolf daemon restart   # restart this project's exact PM2 registration
 openwolf daemon logs      # last 50 lines
 ```
+
+Stop and restart control only the current project's PM2 registration. They
+do not discover or terminate processes by dashboard port.
 
 The daemon handles stale-gated anatomy rescans, measured-usage refresh,
 memory consolidation, and the dashboard server. It makes no network calls.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,19 +111,15 @@ tree-sitter pass.
 
 ## Daemon will not stop
 
-`openwolf daemon stop` handles both PM2-managed and forked daemons, falling
-back to killing the process on the dashboard port. Manual fallback:
+`openwolf daemon stop` and `openwolf daemon restart` control only the current
+project's exact PM2 registration. Check whether that registration exists:
 
-::: code-group
-```bash [macOS/Linux]
-lsof -ti :<port> | xargs kill
+```bash
+pm2 status
 ```
 
-```bash [Windows]
-netstat -ano -p tcp | findstr :<port>
-taskkill /PID <pid> /F
-```
-:::
+If the project is not registered, run `openwolf daemon start`, then retry the
+stop or restart command. Install PM2 with `pnpm add -g pm2` if it is unavailable.
 
 ## Commands say "OpenWolf not initialized"
 

--- a/src/cli/daemon-cmd.ts
+++ b/src/cli/daemon-cmd.ts
@@ -1,25 +1,12 @@
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
-import * as net from "node:net";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { findProjectRoot } from "../scanner/project-root.js";
-import { readJSON } from "../utils/fs-safe.js";
 import { isWindows } from "../utils/platform.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-function getDashboardPort(): number {
-  const projectRoot = findProjectRoot();
-  const wolfDir = path.join(projectRoot, ".wolf");
-  const config = readJSON<{ openwolf: { dashboard: { port: number } } }>(
-    path.join(wolfDir, "config.json"),
-    { openwolf: { dashboard: { port: 18791 } } }
-  );
-  const port = Number(config.openwolf.dashboard.port);
-  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : 18791;
-}
 
 function getPm2Name(): string {
   const projectRoot = findProjectRoot();
@@ -33,47 +20,6 @@ function pm2Bin(): string {
 export function hasPm2(): boolean {
   try {
     execFileSync(isWindows() ? "where" : "which", ["pm2"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function findPidsOnPort(port: number): number[] {
-  const pids = new Set<number>();
-  try {
-    if (isWindows()) {
-      const output = execFileSync("netstat", ["-ano", "-p", "tcp"], { encoding: "utf-8" });
-      for (const line of output.split("\n")) {
-        // Match the local-address column only; a bare `:port` substring also
-        // matched the foreign-address column and killed unrelated processes.
-        if (!line.includes("LISTENING")) continue;
-        const parts = line.trim().split(/\s+/);
-        const local = parts[1] ?? "";
-        if (!local.endsWith(`:${port}`)) continue;
-        const pid = parseInt(parts[parts.length - 1], 10);
-        if (pid > 0) pids.add(pid);
-      }
-    } else {
-      // lsof -ti can return several newline-separated pids; the old parseInt
-      // of the whole output killed only the first and left stale listeners.
-      const output = execFileSync("lsof", ["-ti", `:${port}`], { encoding: "utf-8" });
-      for (const part of output.split("\n")) {
-        const pid = parseInt(part.trim(), 10);
-        if (pid > 0) pids.add(pid);
-      }
-    }
-  } catch {}
-  return [...pids];
-}
-
-function killPid(pid: number): boolean {
-  try {
-    if (isWindows()) {
-      execFileSync("taskkill", ["/PID", String(pid), "/F"], { stdio: "ignore" });
-    } else {
-      process.kill(pid, "SIGTERM");
-    }
     return true;
   } catch {
     return false;
@@ -121,31 +67,19 @@ export function daemonStop(): void {
     return;
   }
 
-  // First try PM2
-  if (hasPm2()) {
-    const name = getPm2Name();
-    try {
-      execFileSync(pm2Bin(), ["stop", name], { stdio: "ignore" });
-      console.log(`  ✓ Daemon stopped (PM2): ${name}`);
-      return;
-    } catch {
-      // PM2 process not found — fall through to port-based stop
-    }
+  if (!hasPm2()) {
+    console.error("Failed to stop daemon: pm2 not found. Install with: pnpm add -g pm2");
+    process.exitCode = 1;
+    return;
   }
 
-  // Fall back to killing whatever is listening on the dashboard port
-  const port = getDashboardPort();
-  const pids = findPidsOnPort(port);
-  if (pids.length > 0) {
-    for (const pid of pids) {
-      if (killPid(pid)) {
-        console.log(`  ✓ Daemon stopped (PID ${pid} on port ${port})`);
-      } else {
-        console.error(`  Failed to kill process ${pid} on port ${port}.`);
-      }
-    }
-  } else {
-    console.log(`  No daemon running on port ${port}.`);
+  const name = getPm2Name();
+  try {
+    execFileSync(pm2Bin(), ["stop", name], { stdio: "ignore" });
+    console.log(`  ✓ Daemon stopped (PM2): ${name}`);
+  } catch {
+    console.error(`Failed to stop daemon (${name}). Run 'pm2 status'; if it is not registered, run 'openwolf daemon start', then retry.`);
+    process.exitCode = 1;
   }
 }
 
@@ -158,25 +92,20 @@ export function daemonRestart(): void {
     return;
   }
 
-  // First try PM2
-  if (hasPm2()) {
-    const name = getPm2Name();
-    try {
-      execFileSync(pm2Bin(), ["restart", name], { stdio: "ignore" });
-      console.log(`  ✓ Daemon restarted (PM2): ${name}`);
-      return;
-    } catch {
-      // PM2 process not found — fall through
-    }
+  if (!hasPm2()) {
+    console.error("Failed to restart daemon: pm2 not found. Install with: pnpm add -g pm2");
+    process.exitCode = 1;
+    return;
   }
 
-  // Fall back: stop then start via dashboard command flow
-  const port = getDashboardPort();
-  for (const pid of findPidsOnPort(port)) {
-    killPid(pid);
-    console.log(`  Stopped old daemon (PID ${pid}).`);
+  const name = getPm2Name();
+  try {
+    execFileSync(pm2Bin(), ["restart", name], { stdio: "ignore" });
+    console.log(`  ✓ Daemon restarted (PM2): ${name}`);
+  } catch {
+    console.error(`Failed to restart daemon (${name}). Run 'pm2 status'; if it is not registered, run 'openwolf daemon start', then retry.`);
+    process.exitCode = 1;
   }
-  console.log("  Use 'openwolf dashboard' to start a new daemon.");
 }
 
 export function daemonStatus(): void {

--- a/src/cli/daemon-cmd.ts
+++ b/src/cli/daemon-cmd.ts
@@ -75,7 +75,11 @@ export function daemonStop(): void {
 
   const name = getPm2Name();
   try {
-    execFileSync(pm2Bin(), ["stop", name], { stdio: "ignore" });
+    if (isWindows()) {
+      execFileSync(process.env.ComSpec || "cmd.exe", ["/d", "/s", "/c", "pm2.cmd", "stop", name], { stdio: "ignore" });
+    } else {
+      execFileSync("pm2", ["stop", name], { stdio: "ignore" });
+    }
     console.log(`  ✓ Daemon stopped (PM2): ${name}`);
   } catch {
     console.error(`Failed to stop daemon (${name}). Run 'pm2 status'; if it is not registered, run 'openwolf daemon start', then retry.`);
@@ -100,7 +104,11 @@ export function daemonRestart(): void {
 
   const name = getPm2Name();
   try {
-    execFileSync(pm2Bin(), ["restart", name], { stdio: "ignore" });
+    if (isWindows()) {
+      execFileSync(process.env.ComSpec || "cmd.exe", ["/d", "/s", "/c", "pm2.cmd", "restart", name], { stdio: "ignore" });
+    } else {
+      execFileSync("pm2", ["restart", name], { stdio: "ignore" });
+    }
     console.log(`  ✓ Daemon restarted (PM2): ${name}`);
   } catch {
     console.error(`Failed to restart daemon (${name}). Run 'pm2 status'; if it is not registered, run 'openwolf daemon start', then retry.`);

--- a/tests/daemon-cmd.test.ts
+++ b/tests/daemon-cmd.test.ts
@@ -1,0 +1,127 @@
+import { test } from "node:test";
+import * as assert from "node:assert";
+import childProcess from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { syncBuiltinESMExports } from "node:module";
+
+test("daemon stop and restart control only the project PM2 registration", async () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openwolf-daemon-cmd-"));
+  const originalCwd = process.cwd();
+  const originalExecFileSync = childProcess.execFileSync;
+  const originalKill = process.kill;
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExitCode = process.exitCode;
+  const probeBin = process.platform === "win32" ? "where" : "which";
+  const pm2Bin = process.platform === "win32" ? "pm2.cmd" : "pm2";
+  const pm2Name = `openwolf-${path.basename(projectRoot).replace(/[^a-zA-Z0-9._-]/g, "-")}`;
+
+  let calls: Array<[string, string[]]> = [];
+  let kills: Array<[number, NodeJS.Signals | number | undefined]> = [];
+  let logs: string[] = [];
+  let errors: string[] = [];
+
+  const fakeListenerOutput = process.platform === "win32"
+    ? "  TCP    127.0.0.1:18791    0.0.0.0:0    LISTENING    4242\n"
+    : "4242\n";
+
+  const run = (action: "stop" | "restart", outcome: "unavailable" | "failed" | "success") => {
+    calls = [];
+    kills = [];
+    logs = [];
+    errors = [];
+    process.exitCode = undefined;
+
+    childProcess.execFileSync = ((command: string, args: readonly string[] = []) => {
+      calls.push([command, [...args]]);
+      if (command === probeBin) {
+        if (outcome === "unavailable") throw new Error("pm2 unavailable");
+        return Buffer.alloc(0);
+      }
+      if (command === pm2Bin && args[0] === action) {
+        if (outcome === "failed") throw new Error("child-secret");
+        return Buffer.alloc(0);
+      }
+      if (command === "lsof" || command === "netstat") return fakeListenerOutput;
+      if (command === "taskkill") return Buffer.alloc(0);
+      throw new Error(`unexpected child process: ${command} ${args.join(" ")}`);
+    }) as typeof childProcess.execFileSync;
+    syncBuiltinESMExports();
+
+    const handler = action === "stop" ? daemonStop : daemonRestart;
+    handler();
+
+    return { calls: [...calls], kills: [...kills], logs: [...logs], errors: [...errors], exitCode: process.exitCode };
+  };
+
+  fs.mkdirSync(path.join(projectRoot, ".wolf"));
+  process.chdir(projectRoot);
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    kills.push([pid, signal]);
+    return true;
+  }) as typeof process.kill;
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+
+  const { daemonStop, daemonRestart } = await import("../dist/src/cli/daemon-cmd.js");
+
+  try {
+    const unavailableStop = run("stop", "unavailable");
+    assert.equal(unavailableStop.kills.length, 0, "issue #8: stop signaled an unverified port PID");
+    assert.deepEqual(unavailableStop.calls, [[probeBin, ["pm2"]]]);
+    assert.equal(unavailableStop.exitCode, 1);
+    assert.match(unavailableStop.errors.join("\n"), /stop/i);
+    assert.match(unavailableStop.errors.join("\n"), /pm2/i);
+    assert.match(unavailableStop.errors.join("\n"), /install/i);
+
+    const unavailableRestart = run("restart", "unavailable");
+    assert.deepEqual(unavailableRestart.calls, [[probeBin, ["pm2"]]]);
+    assert.equal(unavailableRestart.kills.length, 0);
+    assert.equal(unavailableRestart.exitCode, 1);
+    assert.match(unavailableRestart.errors.join("\n"), /restart/i);
+    assert.match(unavailableRestart.errors.join("\n"), /pm2/i);
+    assert.match(unavailableRestart.errors.join("\n"), /install/i);
+
+    for (const action of ["stop", "restart"] as const) {
+      const failed = run(action, "failed");
+      assert.deepEqual(failed.calls, [
+        [probeBin, ["pm2"]],
+        [pm2Bin, [action, pm2Name]],
+      ]);
+      assert.equal(failed.kills.length, 0);
+      assert.equal(failed.exitCode, 1);
+      const error = failed.errors.join("\n");
+      assert.match(error, new RegExp(action, "i"));
+      assert.match(error, new RegExp(pm2Name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+      assert.match(error, /pm2 status/i);
+      assert.match(error, /openwolf daemon start/i);
+      assert.match(error, /retry/i);
+      assert.doesNotMatch(error, /child-secret/);
+
+      const success = run(action, "success");
+      assert.deepEqual(success.calls, [
+        [probeBin, ["pm2"]],
+        [pm2Bin, [action, pm2Name]],
+      ]);
+      assert.equal(success.kills.length, 0);
+      assert.equal(success.exitCode, undefined);
+      assert.deepEqual(success.errors, []);
+      assert.ok(success.logs.includes(
+        action === "stop"
+          ? `  ✓ Daemon stopped (PM2): ${pm2Name}`
+          : `  ✓ Daemon restarted (PM2): ${pm2Name}`
+      ));
+    }
+  } finally {
+    childProcess.execFileSync = originalExecFileSync;
+    syncBuiltinESMExports();
+    process.kill = originalKill;
+    console.log = originalLog;
+    console.error = originalError;
+    process.exitCode = originalExitCode;
+    process.chdir(originalCwd);
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/daemon-cmd.test.ts
+++ b/tests/daemon-cmd.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import * as assert from "node:assert";
 import childProcess from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
+import os from "node:os";
 import * as path from "node:path";
 import { syncBuiltinESMExports } from "node:module";
 
@@ -10,12 +10,14 @@ test("daemon stop and restart control only the project PM2 registration", async 
   const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openwolf-daemon-cmd-"));
   const originalCwd = process.cwd();
   const originalExecFileSync = childProcess.execFileSync;
+  const originalPlatform = os.platform;
   const originalKill = process.kill;
   const originalLog = console.log;
   const originalError = console.error;
   const originalExitCode = process.exitCode;
-  const probeBin = process.platform === "win32" ? "where" : "which";
-  const pm2Bin = process.platform === "win32" ? "pm2.cmd" : "pm2";
+  const hadComSpec = Object.hasOwn(process.env, "ComSpec");
+  const originalComSpec = process.env.ComSpec;
+  const windowsComSpec = "C:\\Windows\\System32\\cmd.exe";
   const pm2Name = `openwolf-${path.basename(projectRoot).replace(/[^a-zA-Z0-9._-]/g, "-")}`;
 
   let calls: Array<[string, string[]]> = [];
@@ -23,28 +25,31 @@ test("daemon stop and restart control only the project PM2 registration", async 
   let logs: string[] = [];
   let errors: string[] = [];
 
-  const fakeListenerOutput = process.platform === "win32"
-    ? "  TCP    127.0.0.1:18791    0.0.0.0:0    LISTENING    4242\n"
-    : "4242\n";
-
-  const run = (action: "stop" | "restart", outcome: "unavailable" | "failed" | "success") => {
+  const run = (
+    action: "stop" | "restart",
+    outcome: "unavailable" | "failed" | "success",
+    platform: NodeJS.Platform
+  ) => {
     calls = [];
     kills = [];
     logs = [];
     errors = [];
     process.exitCode = undefined;
+    os.platform = (() => platform) as typeof os.platform;
 
     childProcess.execFileSync = ((command: string, args: readonly string[] = []) => {
       calls.push([command, [...args]]);
+      const probeBin = platform === "win32" ? "where" : "which";
       if (command === probeBin) {
         if (outcome === "unavailable") throw new Error("pm2 unavailable");
         return Buffer.alloc(0);
       }
-      if (command === pm2Bin && args[0] === action) {
+      const actionBin = platform === "win32" ? windowsComSpec : "pm2";
+      if (command === actionBin) {
         if (outcome === "failed") throw new Error("child-secret");
         return Buffer.alloc(0);
       }
-      if (command === "lsof" || command === "netstat") return fakeListenerOutput;
+      if (command === "lsof" || command === "netstat") return "4242\n";
       if (command === "taskkill") return Buffer.alloc(0);
       throw new Error(`unexpected child process: ${command} ${args.join(" ")}`);
     }) as typeof childProcess.execFileSync;
@@ -64,63 +69,78 @@ test("daemon stop and restart control only the project PM2 registration", async 
   }) as typeof process.kill;
   console.log = (...args: unknown[]) => logs.push(args.join(" "));
   console.error = (...args: unknown[]) => errors.push(args.join(" "));
+  process.env.ComSpec = windowsComSpec;
 
   const { daemonStop, daemonRestart } = await import("../dist/src/cli/daemon-cmd.js");
 
   try {
-    const unavailableStop = run("stop", "unavailable");
+    const unavailableStop = run("stop", "unavailable", "linux");
     assert.equal(unavailableStop.kills.length, 0, "issue #8: stop signaled an unverified port PID");
-    assert.deepEqual(unavailableStop.calls, [[probeBin, ["pm2"]]]);
+    assert.deepEqual(unavailableStop.calls, [["which", ["pm2"]]]);
     assert.equal(unavailableStop.exitCode, 1);
     assert.match(unavailableStop.errors.join("\n"), /stop/i);
     assert.match(unavailableStop.errors.join("\n"), /pm2/i);
     assert.match(unavailableStop.errors.join("\n"), /install/i);
 
-    const unavailableRestart = run("restart", "unavailable");
-    assert.deepEqual(unavailableRestart.calls, [[probeBin, ["pm2"]]]);
+    const unavailableRestart = run("restart", "unavailable", "linux");
+    assert.deepEqual(unavailableRestart.calls, [["which", ["pm2"]]]);
     assert.equal(unavailableRestart.kills.length, 0);
     assert.equal(unavailableRestart.exitCode, 1);
     assert.match(unavailableRestart.errors.join("\n"), /restart/i);
     assert.match(unavailableRestart.errors.join("\n"), /pm2/i);
     assert.match(unavailableRestart.errors.join("\n"), /install/i);
 
-    for (const action of ["stop", "restart"] as const) {
-      const failed = run(action, "failed");
-      assert.deepEqual(failed.calls, [
-        [probeBin, ["pm2"]],
-        [pm2Bin, [action, pm2Name]],
-      ]);
-      assert.equal(failed.kills.length, 0);
-      assert.equal(failed.exitCode, 1);
-      const error = failed.errors.join("\n");
-      assert.match(error, new RegExp(action, "i"));
-      assert.match(error, new RegExp(pm2Name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-      assert.match(error, /pm2 status/i);
-      assert.match(error, /openwolf daemon start/i);
-      assert.match(error, /retry/i);
-      assert.doesNotMatch(error, /child-secret/);
+    for (const platform of ["win32", "linux"] as const) {
+      for (const action of ["stop", "restart"] as const) {
+        const expectedCalls: Array<[string, string[]]> = platform === "win32"
+          ? [
+              ["where", ["pm2"]],
+              [windowsComSpec, ["/d", "/s", "/c", "pm2.cmd", action, pm2Name]],
+            ]
+          : [
+              ["which", ["pm2"]],
+              ["pm2", [action, pm2Name]],
+            ];
+        const failed = run(action, "failed", platform);
+        assert.deepEqual(
+          failed.calls,
+          expectedCalls,
+          platform === "win32" && action === "stop"
+            ? "issue #8 Windows: stop invoked pm2.cmd directly"
+            : undefined
+        );
+        assert.equal(failed.kills.length, 0);
+        assert.equal(failed.exitCode, 1);
+        const error = failed.errors.join("\n");
+        assert.match(error, new RegExp(action, "i"));
+        assert.match(error, new RegExp(pm2Name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+        assert.match(error, /pm2 status/i);
+        assert.match(error, /openwolf daemon start/i);
+        assert.match(error, /retry/i);
+        assert.doesNotMatch(error, /child-secret/);
 
-      const success = run(action, "success");
-      assert.deepEqual(success.calls, [
-        [probeBin, ["pm2"]],
-        [pm2Bin, [action, pm2Name]],
-      ]);
-      assert.equal(success.kills.length, 0);
-      assert.equal(success.exitCode, undefined);
-      assert.deepEqual(success.errors, []);
-      assert.ok(success.logs.includes(
-        action === "stop"
-          ? `  ✓ Daemon stopped (PM2): ${pm2Name}`
-          : `  ✓ Daemon restarted (PM2): ${pm2Name}`
-      ));
+        const success = run(action, "success", platform);
+        assert.deepEqual(success.calls, expectedCalls);
+        assert.equal(success.kills.length, 0);
+        assert.equal(success.exitCode, undefined);
+        assert.deepEqual(success.errors, []);
+        assert.ok(success.logs.includes(
+          action === "stop"
+            ? `  ✓ Daemon stopped (PM2): ${pm2Name}`
+            : `  ✓ Daemon restarted (PM2): ${pm2Name}`
+        ));
+      }
     }
   } finally {
     childProcess.execFileSync = originalExecFileSync;
+    os.platform = originalPlatform;
     syncBuiltinESMExports();
     process.kill = originalKill;
     console.log = originalLog;
     console.error = originalError;
     process.exitCode = originalExitCode;
+    if (hadComSpec) process.env.ComSpec = originalComSpec;
+    else delete process.env.ComSpec;
     process.chdir(originalCwd);
     fs.rmSync(projectRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What

- Restrict daemon stop and restart to the exact project-derived PM2 process name.
- Remove port-listener discovery and unverified PID termination fallbacks.
- Use fixed argv through `cmd.exe` for Windows PM2 commands.

## Why

Closes #78.

Mirrors [davdittrich/openwolf#8](https://github.com/davdittrich/openwolf/issues/8).

## How

- Fail nonzero with actionable guidance when PM2 is unavailable or control fails.
- Cover unavailable, failure, success, Windows, and no-signal behavior with boundary-spy tests.
- Update command and troubleshooting documentation to match PM2-only ownership.