### PR TITLE
fix: isolate OpenCode session persistence

### DIFF
--- a/src/templates/opencode-plugin/fs.ts
+++ b/src/templates/opencode-plugin/fs.ts
@@ -6,6 +6,27 @@ export function getWolfDir(directory: string): string {
   return path.join(directory, ".wolf")
 }
 
+export function getSessionFilePath(directory: string, sessionId: string): string {
+  const hooksDir = path.join(getWolfDir(directory), "hooks")
+  return /^[\w.-]{4,128}$/.test(sessionId)
+    ? path.join(hooksDir, "sessions", `${sessionId}.json`)
+    : path.join(hooksDir, "_session.json")
+}
+
+export function gcSessionFiles(directory: string, maxAgeDays = 7): void {
+  try {
+    const dir = path.join(getWolfDir(directory), "hooks", "sessions")
+    const cutoff = Date.now() - maxAgeDays * 24 * 3600 * 1000
+    for (const file of fs.readdirSync(dir)) {
+      if (!file.endsWith(".json")) continue
+      try {
+        const filePath = path.join(dir, file)
+        if (fs.statSync(filePath).mtimeMs < cutoff) fs.unlinkSync(filePath)
+      } catch {}
+    }
+  } catch {}
+}
+
 export function wolfDirExists(directory: string): boolean {
   return fs.existsSync(getWolfDir(directory))
 }

--- a/src/templates/opencode-plugin/post-read.ts
+++ b/src/templates/opencode-plugin/post-read.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { getWolfDir, writeJSON, readJSON, normalizePath, estimateTokens } from "./fs.js"
+import { getWolfDir, getSessionFilePath, writeJSON, readJSON, normalizePath, estimateTokens } from "./fs.js"
 import { lookupEntry } from "./anatomy.js"
 import type { PartialSessionState } from "./types.js"
 
@@ -8,8 +8,7 @@ export function handlePostRead(directory: string, sessionId: string, filePath: s
   const wolfDir = getWolfDir(directory)
   if (!fs.existsSync(wolfDir)) return
 
-  const hooksDir = path.join(wolfDir, "hooks")
-  const sessionFile = path.join(hooksDir, "_session.json")
+  const sessionFile = getSessionFilePath(directory, sessionId)
   const normalizedFile = normalizePath(filePath)
 
   const projectDir = normalizePath(directory)

--- a/src/templates/opencode-plugin/post-write.ts
+++ b/src/templates/opencode-plugin/post-write.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 import * as crypto from "node:crypto"
-import { getWolfDir, writeJSON, readJSON, appendMarkdown, timeShort, normalizePath, estimateTokens, isSensitiveFile } from "./fs.js"
+import { getWolfDir, getSessionFilePath, writeJSON, readJSON, appendMarkdown, timeShort, normalizePath, estimateTokens, isSensitiveFile } from "./fs.js"
 import { extractDescription, withAnatomyLock, loadStoreReconciled, saveStore, renderToFile, sha256, LOCK_BUDGET_MS } from "./anatomy.js"
 import type { PartialSessionState, FixDetection } from "./types.js"
 
@@ -28,8 +28,7 @@ export function handlePostWrite(
   const wolfDir = getWolfDir(directory)
   if (!fs.existsSync(wolfDir)) return
 
-  const hooksDir = path.join(wolfDir, "hooks")
-  const sessionFile = path.join(hooksDir, "_session.json")
+  const sessionFile = getSessionFilePath(directory, sessionId)
   const projectRoot = directory
 
   const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(projectRoot, filePath)

--- a/src/templates/opencode-plugin/pre-read.ts
+++ b/src/templates/opencode-plugin/pre-read.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { getWolfDir, writeJSON, readJSON, normalizePath } from "./fs.js"
+import { getWolfDir, getSessionFilePath, writeJSON, readJSON, normalizePath } from "./fs.js"
 import { lookupEntry } from "./anatomy.js"
 import type { PartialSessionState } from "./types.js"
 
@@ -8,8 +8,7 @@ export function handlePreRead(directory: string, sessionId: string, filePath: st
   const wolfDir = getWolfDir(directory)
   if (!fs.existsSync(wolfDir)) return
 
-  const hooksDir = path.join(wolfDir, "hooks")
-  const sessionFile = path.join(hooksDir, "_session.json")
+  const sessionFile = getSessionFilePath(directory, sessionId)
   const normalizedFile = normalizePath(filePath)
 
   const projectDir = normalizePath(directory)

--- a/src/templates/opencode-plugin/session.ts
+++ b/src/templates/opencode-plugin/session.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { getWolfDir, writeJSON, readJSON, appendMarkdown, timeShort, timestamp, readMarkdown } from "./fs.js"
+import { getWolfDir, getSessionFilePath, gcSessionFiles, writeJSON, readJSON, appendMarkdown, timeShort, timestamp, readMarkdown } from "./fs.js"
 import type { SessionState } from "./types.js"
 
 const sessions = new Map<string, SessionState>()
@@ -23,6 +23,7 @@ export function handleSessionStart(directory: string, sessionId: string): void {
 
   const hooksDir = path.join(wolfDir, "hooks")
   fs.mkdirSync(hooksDir, { recursive: true })
+  gcSessionFiles(directory)
 
   try {
     const files = fs.readdirSync(wolfDir)
@@ -33,7 +34,7 @@ export function handleSessionStart(directory: string, sessionId: string): void {
     }
   } catch {}
 
-  const sessionFile = path.join(hooksDir, "_session.json")
+  const sessionFile = getSessionFilePath(directory, sessionId)
   const state: SessionState = {
     session_id: sessionId,
     started: timestamp(),

--- a/src/templates/opencode-plugin/stop.ts
+++ b/src/templates/opencode-plugin/stop.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { getWolfDir, writeJSON, readJSON, appendMarkdown, timeShort } from "./fs.js"
+import { getWolfDir, getSessionFilePath, writeJSON, readJSON, appendMarkdown, timeShort } from "./fs.js"
 import type { SessionState } from "./types.js"
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -205,8 +205,7 @@ export function handleStop(directory: string, sessionId: string): void {
   const wolfDir = getWolfDir(directory)
   if (!fs.existsSync(wolfDir)) return
 
-  const hooksDir = path.join(wolfDir, "hooks")
-  const sessionFile = path.join(hooksDir, "_session.json")
+  const sessionFile = getSessionFilePath(directory, sessionId)
 
   const session = readJSON<SessionState>(sessionFile, {
     session_id: "", started: "", files_read: {}, files_written: [],

--- a/tests/opencode-session-isolation.test.ts
+++ b/tests/opencode-session-isolation.test.ts
@@ -1,0 +1,142 @@
+import * as assert from "node:assert";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { test } from "node:test";
+import ts from "typescript";
+
+type OpenCodeHooks = {
+  event(input: { event: { type: string; [key: string]: unknown } }): Promise<void>;
+  "tool.execute.before"(input: { tool: string; sessionID: string }, output: { args: Record<string, unknown> }): Promise<void>;
+  "tool.execute.after"(input: { tool: string; sessionID: string; args: Record<string, unknown> }, output: Record<string, unknown>): Promise<void>;
+  stop(input: Record<string, unknown>): Promise<void>;
+};
+
+type SessionPathCall = {
+  handler: "handleSessionStart" | "handlePreRead" | "handlePostRead" | "handlePostWrite" | "handleStop";
+  sessionId: string;
+  resolvedPath: string;
+};
+
+test("OpenCode keeps valid session persistence isolated and invalid IDs on the legacy fallback", async (t) => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), "openwolf-opencode-session-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const resolverCalls: SessionPathCall[] = [];
+  const auditGlobal = globalThis as typeof globalThis & {
+    __openwolfSessionPathAudit?: (handler: SessionPathCall["handler"], sessionId: string, resolvedPath: string) => string;
+  };
+  auditGlobal.__openwolfSessionPathAudit = (handler, sessionId, resolvedPath) => {
+    resolverCalls.push({ handler, sessionId, resolvedPath });
+    return resolvedPath;
+  };
+
+  try {
+    const sourceDir = path.resolve(import.meta.dirname, "../src/templates/opencode-plugin");
+    const outputDir = path.join(root, "plugin");
+    const sources = fs.readdirSync(sourceDir).filter((file) => file.endsWith(".ts")).map((file) => path.join(sourceDir, file));
+    const handlersByFile = new Map<string, SessionPathCall["handler"]>([
+      ["session.js", "handleSessionStart"],
+      ["pre-read.js", "handlePreRead"],
+      ["post-read.js", "handlePostRead"],
+      ["post-write.js", "handlePostWrite"],
+      ["stop.js", "handleStop"],
+    ]);
+    fs.mkdirSync(outputDir);
+    sources.forEach((source) => {
+      const outputFile = path.basename(source).replace(/\.ts$/, ".js");
+      const emitted = ts.transpileModule(fs.readFileSync(source, "utf-8"), {
+        compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 },
+        fileName: source,
+      });
+      let outputText = emitted.outputText;
+      const handler = handlersByFile.get(outputFile);
+      if (handler) {
+        const resolverCall = "getSessionFilePath(directory, sessionId)";
+        assert.strictEqual(outputText.split(resolverCall).length - 1, 1, `${handler} must call the shared resolver exactly once`);
+        outputText = outputText.replace(
+          resolverCall,
+          `globalThis.__openwolfSessionPathAudit("${handler}", sessionId, ${resolverCall})`,
+        );
+      }
+      fs.writeFileSync(path.join(outputDir, outputFile), outputText, "utf-8");
+    });
+
+    const { OpenWolf } = await import(pathToFileURL(path.join(outputDir, "index.js")).href);
+
+    const wolfDir = path.join(root, ".wolf");
+    fs.mkdirSync(wolfDir, { recursive: true });
+    const sessionsDir = path.join(wolfDir, "hooks", "sessions");
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const expiredSessionPath = path.join(sessionsDir, "expired-session.json");
+    const freshSessionPath = path.join(sessionsDir, "fresh-session.json");
+    fs.writeFileSync(expiredSessionPath, "{}\n", "utf-8");
+    fs.writeFileSync(freshSessionPath, "{}\n", "utf-8");
+    const now = new Date();
+    const expired = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(expiredSessionPath, expired, expired);
+    fs.utimesSync(freshSessionPath, now, now);
+
+    const hooks = await OpenWolf({ directory: root }) as OpenCodeHooks;
+    const sessionA = "session-a1";
+    const sessionB = "session-b2";
+
+    await hooks.event({ event: { type: "session.created", properties: { info: { id: sessionA } } } });
+    assert.ok(!fs.existsSync(expiredSessionPath), "session start must remove files older than seven days");
+    assert.ok(fs.existsSync(freshSessionPath), "session start must retain fresh session files");
+    await hooks.event({ event: { type: "session.created", properties: { info: { id: sessionB } } } });
+
+    const readFile = path.join(root, "read-a.ts");
+    fs.writeFileSync(readFile, "export const a = 1;\n", "utf-8");
+    await hooks["tool.execute.before"]({ tool: "read", sessionID: sessionA }, { args: { filePath: readFile } });
+    await hooks["tool.execute.after"]({ tool: "read", sessionID: sessionA, args: { filePath: readFile } }, { output: "export const a = 1;\n" });
+
+    const writeFile = path.join(root, "write-b.ts");
+    fs.writeFileSync(writeFile, "export const b = 2;\n", "utf-8");
+    await hooks["tool.execute.after"](
+      { tool: "write", sessionID: sessionB, args: { filePath: writeFile, content: "export const b = 2;\n" } },
+      {},
+    );
+
+    await hooks.stop({ sessionID: sessionA });
+    await hooks.stop({ sessionID: sessionB });
+
+    const sessionAPath = path.join(sessionsDir, `${sessionA}.json`);
+    const sessionBPath = path.join(sessionsDir, `${sessionB}.json`);
+    assert.notStrictEqual(sessionAPath, sessionBPath);
+    assert.ok(fs.existsSync(sessionAPath), "session A must have its own persistent state file");
+    assert.ok(fs.existsSync(sessionBPath), "session B must have its own persistent state file");
+
+    const stateA = JSON.parse(fs.readFileSync(sessionAPath, "utf-8"));
+    const stateB = JSON.parse(fs.readFileSync(sessionBPath, "utf-8"));
+    assert.strictEqual(stateA.session_id, sessionA);
+    assert.strictEqual(stateB.session_id, sessionB);
+    assert.ok(stateA.files_read[readFile]);
+    assert.deepStrictEqual(stateA.files_written, []);
+    assert.ok(stateB.files_written.some((entry: { file: string }) => entry.file === writeFile));
+    assert.deepStrictEqual(stateB.files_read, {});
+    assert.strictEqual(stateA.stop_count, 1);
+    assert.strictEqual(stateB.stop_count, 1);
+
+    const ledger = JSON.parse(fs.readFileSync(path.join(wolfDir, "token-ledger.json"), "utf-8"));
+    assert.deepStrictEqual(ledger.sessions.map((entry: { id: string }) => entry.id).sort(), [sessionA, sessionB]);
+
+    const invalidId = "bad/id";
+    await hooks.event({ event: { type: "session.created", sessionID: invalidId } });
+    const fallbackPath = path.join(wolfDir, "hooks", "_session.json");
+    assert.strictEqual(JSON.parse(fs.readFileSync(fallbackPath, "utf-8")).session_id, invalidId);
+    await hooks.event({ event: { type: "session.created" } });
+    assert.strictEqual(JSON.parse(fs.readFileSync(fallbackPath, "utf-8")).session_id, invalidId);
+
+    assert.deepStrictEqual(
+      [...new Set(resolverCalls.map(({ handler }) => handler))].sort(),
+      ["handleSessionStart", "handlePreRead", "handlePostRead", "handlePostWrite", "handleStop"].sort(),
+    );
+    for (const call of resolverCalls.filter(({ sessionId }) => sessionId === sessionA || sessionId === sessionB)) {
+      assert.strictEqual(call.resolvedPath, call.sessionId === sessionA ? sessionAPath : sessionBPath);
+    }
+  } finally {
+    delete auditGlobal.__openwolfSessionPathAudit;
+  }
+});


### PR DESCRIPTION
## What

Persist OpenCode hook state per valid session ID and garbage-collect session files older than seven days. Invalid or missing IDs retain the legacy `_session.json` fallback.

## Why

Concurrent OpenCode sessions previously shared one state file, allowing lifecycle, read/write, ledger, and stop accounting to overwrite each other.

## Verification

- Focused public-boundary regression: pass
- Full Node test suite: 199 passed
- TypeScript `--noEmit`: pass
- Critical, Antigravity, and Claude exact-SHA reviews: pass

Fixes cytostack/openwolf#89.