### PR TITLE
fix(hooks): guard pre-write basename against missing bug.file

### DIFF
--- a/src/hooks/pre-write.ts
+++ b/src/hooks/pre-write.ts
@@ -137,7 +137,7 @@ function checkBugLog(wolfDir: string, filePath: string, oldStr: string, newStr: 
   if (relevant === null) {
     // Legacy path: ONLY surface bugs recorded against the SAME file.
     const fileMatches = bugLog.bugs.filter(b => {
-      const bugBasename = path.basename(b.file);
+      const bugBasename = path.basename(b.file ?? "");
       return bugBasename === basename;
     });
     if (fileMatches.length === 0) return [];


### PR DESCRIPTION
## What

`checkBugLog()`'s legacy fallback in `src/hooks/pre-write.ts` (used whenever `searchBugsFTS()` returns `null`, e.g. `node:sqlite` isn't available — `No such built-in module` on Node 20.19.6) calls `path.basename(b.file)` with no guard:

```ts
const fileMatches = bugLog.bugs.filter(b => {
  const bugBasename = path.basename(b.file);
  return bugBasename === basename;
});
```

`BugEntry.file` is typed as `string`, but nothing enforces that at runtime — `buglog.json` entries commonly don't have a `file` field. When one doesn't, `path.basename(undefined)` throws `ERR_INVALID_ARG_TYPE`, which kills `pre-write` on **every** subsequent Edit/Write call for the rest of the session (silently — no error surfaces beyond the dashboard's failure counter). Observed 164+ consecutive failures in a real project.

The FTS path a few lines above already guards this correctly (`bug.file ?? ""`) — this PR applies the same guard to the legacy fallback.

## Why

Once this fires, the Do-Not-Repeat/buglog pre-check is silently disabled for the rest of the session (and stays disabled across sessions/`openwolf update`, since it reinstalls the same template) — the exact safety net the hook exists to provide.

## Repro

1. Node without `node:sqlite` (e.g. 20.19.6).
2. Any `buglog.json` entry missing `file`.
3. Any Edit/Write with non-empty `old_string`/`content`.

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at Module.basename (node:path:1430:5)
    at Array.filter (<anonymous>)
    at checkBugLog (.../pre-write.js:114:41)
    at main (.../pre-write.js:33:23)
```

## Testing

- `pnpm build` passes.
- Verified locally: before the fix, `pre-write` heartbeat showed `consecutive_failures: 164`; after, it resets to `0` on the next call.