### PR TITLE
fix(hooks): cap decay_reinjection note size in post-batch

### DIFF
--- a/src/hooks/post-batch.ts
+++ b/src/hooks/post-batch.ts
@@ -42,6 +42,11 @@ async function main(): Promise<void> {
   try {
     rules = topRules(fs.readFileSync(path.join(wolfDir, "cerebrum.md"), "utf-8"), 3);
   } catch {}
+  // Do-Not-Repeat entries can be long paragraphs, not the "short factual
+  // statement" this countermeasure assumes — cap each one so a periodic
+  // reinjection can't balloon past the intended ~100 tok/rule budget.
+  const MAX_RULE_CHARS = 200;
+  rules = rules.map((r) => (r.length > MAX_RULE_CHARS ? r.slice(0, MAX_RULE_CHARS) + "…" : r));
 
   // tool_batches is a counter driving an every-Nth-batch reinjection: an
   // unlocked increment both undercounts and can fire the note twice (#83).


### PR DESCRIPTION
## What

The `post-batch.ts` decay countermeasure re-surfaces the top 3 Do-Not-Repeat rules from `cerebrum.md` every `reinjection_interval` tool batches (default 25). It's documented as "short factual statements (~100 tokens)" but the note is built with no cap at all:

```ts
const note = `Project rules still in effect (from .wolf/cerebrum.md Do-Not-Repeat):\n${rules.join("\n")}`;
```

Unlike the session digest (`session_digest_budget_tokens`), this path has zero budget. In a real project, `## Do-Not-Repeat` entries end up as full paragraphs rather than one-liners (realistic after weeks of accumulated learnings), so a single reinjection of 3 rules measured **4392** and **3030** tokens across two sessions in `token-ledger.json` — several times the entire configured digest budget (1500), and firing repeatedly for the life of a long session.

This PR caps each rule to 200 chars before joining:

```ts
const MAX_RULE_CHARS = 200;
rules = rules.map((r) => (r.length > MAX_RULE_CHARS ? r.slice(0, MAX_RULE_CHARS) + "…" : r));
```

## Why

Keeps the reinjection close to its documented intent (~100 tok/rule) instead of silently becoming the single largest token cost in long sessions.

## Testing

- `pnpm build` passes.
- Verified locally against a real `cerebrum.md`: note size went from ~4000 tokens (untruncated, 3 paragraph-length rules) to ~170 tokens with the cap.